### PR TITLE
Migrate to the SQLAlchemy Async API

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -64,7 +64,7 @@ class Settings(BaseSettings):
             return connection_str
 
         return PostgresDsn.build(
-            scheme="postgresql",
+            scheme="postgresql+asyncpg",
             user=values.get("POSTGRES_USER"),
             password=values.get("POSTGRES_PASSWORD"),
             host=values.get("POSTGRES_SERVER"),
@@ -85,7 +85,7 @@ class Settings(BaseSettings):
             return connection_str
 
         return PostgresDsn.build(
-            scheme="postgresql",
+            scheme="postgresql+asyncpg",
             user=values.get("POSTGRES_USER"),
             password=values.get("POSTGRES_PASSWORD"),
             host=values.get("POSTGRES_SERVER"),

--- a/app/crud/base.py
+++ b/app/crud/base.py
@@ -6,7 +6,8 @@ from typing import Any, Dict, Generic, List, Optional, Type, TypeVar, Union
 
 from fastapi.encoders import jsonable_encoder
 from pydantic import BaseModel
-from sqlalchemy.orm import Session
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.db.base_class import Base
 
@@ -32,26 +33,31 @@ class CRUDBase(Generic[ModelType, CreateSchemaType, UpdateSchemaType]):
 
         self.model = model
 
-    def get(self, db_session: Session, identifier: int) -> Optional[ModelType]:
+    async def get(
+        self, db_session: AsyncSession, identifier: int
+    ) -> Optional[ModelType]:
         """
         Obtain model instance by `identifier`.
 
         Returns `None` on unsuccessful search.
         """
 
-        return db_session.get(self.model, identifier)
+        return await db_session.get(self.model, identifier)
 
-    def get_multi(
-        self, db_session: Session, *, skip: int = 0, limit: int = 100
+    async def get_multi(
+        self, db_session: AsyncSession, *, skip: int = 0, limit: int = 100
     ) -> List[ModelType]:
         """
         Obtain a list of model instances starting at offset `skip` and containing a
         maximum of `limit` number of elements.
         """
 
-        return db_session.query(self.model).offset(skip).limit(limit).all()
+        statement = select(self.model).offset(skip).limit(limit)
+        return (await db_session.execute(statement)).scalars().all()
 
-    def create(self, db_session: Session, *, obj_in: CreateSchemaType) -> ModelType:
+    async def create(
+        self, db_session: AsyncSession, *, obj_in: CreateSchemaType
+    ) -> ModelType:
         """
         Create an instance of the model and insert it into the database.
         """
@@ -60,14 +66,14 @@ class CRUDBase(Generic[ModelType, CreateSchemaType, UpdateSchemaType]):
         db_obj = self.model(**obj_in_data)  # type: ignore
 
         db_session.add(db_obj)
-        db_session.commit()
-        db_session.refresh(db_obj)
+        await db_session.commit()
+        await db_session.refresh(db_obj)
 
         return db_obj
 
-    def update(  # pylint: disable=no-self-use
+    async def update(  # pylint: disable=no-self-use
         self,
-        db_session: Session,
+        db_session: AsyncSession,
         *,
         db_obj: ModelType,
         obj_in: Union[UpdateSchemaType, Dict[str, Any]],
@@ -104,19 +110,19 @@ class CRUDBase(Generic[ModelType, CreateSchemaType, UpdateSchemaType]):
                 setattr(db_obj, field, update_data[field])
 
         db_session.add(db_obj)
-        db_session.commit()
-        db_session.refresh(db_obj)
+        await db_session.commit()
+        await db_session.refresh(db_obj)
 
         return db_obj
 
-    def remove(self, db_session: Session, *, identifier: int) -> ModelType:
+    async def remove(self, db_session: AsyncSession, *, identifier: int) -> ModelType:
         """
         Delete model instance by `identifier`.
         """
 
-        obj = db_session.get(self.model, identifier)
+        obj = await db_session.get(self.model, identifier)
 
-        db_session.delete(obj)
-        db_session.commit()
+        await db_session.delete(obj)
+        await db_session.commit()
 
         return obj

--- a/app/crud/crud_question_order_item.py
+++ b/app/crud/crud_question_order_item.py
@@ -4,7 +4,8 @@ CRUD operations on `QuestionOrderItem` model instances.
 
 from typing import Optional
 
-from sqlalchemy.orm import Session
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.crud.base import CRUDBase
 from app.models.question_order_item import QuestionOrderItem
@@ -22,32 +23,31 @@ class CRUDQuestionOrderItem(
     """
 
     @staticmethod
-    def get_by_question_number(
-        db_session: Session, *, question_number: int
+    async def get_by_question_number(
+        db_session: AsyncSession, *, question_number: int
     ) -> Optional[QuestionOrderItem]:
         """
         Obtain question order item by question number.
         """
 
-        return (
-            db_session.query(QuestionOrderItem)
-            .filter(QuestionOrderItem.question_number == question_number)
-            .first()
+        statement = select(QuestionOrderItem).where(
+            QuestionOrderItem.question_number == question_number
         )
 
+        return (await db_session.execute(statement)).scalar_one_or_none()
+
     @staticmethod
-    def get_by_question_id(
-        db_session: Session, *, question_id: int
+    async def get_by_question_id(
+        db_session: AsyncSession, *, question_id: int
     ) -> Optional[QuestionOrderItem]:
         """
         Obtain question order item by question ID.
         """
 
-        return (
-            db_session.query(QuestionOrderItem)
-            .filter(QuestionOrderItem.question_id == question_id)
-            .first()
+        statement = select(QuestionOrderItem).where(
+            QuestionOrderItem.question_id == question_id
         )
+        return (await db_session.execute(statement)).scalar_one_or_none()
 
 
 question_order_item = CRUDQuestionOrderItem(QuestionOrderItem)

--- a/app/crud/crud_user.py
+++ b/app/crud/crud_user.py
@@ -5,6 +5,8 @@ CRUD operations on `User` model instances.
 from typing import Any, Dict, List, Optional, Union
 
 from sqlalchemy import func
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.future import select
 from sqlalchemy.orm import Session
 
 from app.core.security import get_password_hash, verify_password
@@ -19,12 +21,13 @@ class CRUDUser(CRUDBase[User, UserCreate, UserUpdate]):
     """
 
     @staticmethod
-    def get_by_email(db_session: Session, *, email: str) -> Optional[User]:
+    async def get_by_email(db_session: AsyncSession, *, email: str) -> Optional[User]:
         """
         Obtain user by email address.
         """
 
-        return db_session.query(User).filter(User.email == email).first()
+        statement = select(User).where(User.email == email)
+        return (await db_session.execute(statement)).scalar_one_or_none()
 
     def create(self, db_session: Session, *, obj_in: UserCreate) -> User:
         """

--- a/app/crud/crud_user.py
+++ b/app/crud/crud_user.py
@@ -175,7 +175,6 @@ class CRUDUser(CRUDBase[User, UserCreate, UserUpdate]):
             .where(User.is_superuser == False)  # pylint: disable=singleton-comparison
             .cte(name="id_ranks")
         )
-        # id_ranks = await db_session.execute(statement)
         statement = (
             update(User)
             .where(

--- a/app/db/init_db.py
+++ b/app/db/init_db.py
@@ -2,7 +2,7 @@
 Creates initial data (first superuser) in the database.
 """
 
-from sqlalchemy.orm import Session
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from app import LOGGER, crud, schemas
 from app.core.config import settings
@@ -13,7 +13,7 @@ from app.db import base  # pylint: disable=unused-import
 # For more details: https://github.com/tiangolo/full-stack-fastapi-postgresql/issues/28
 
 
-def init_db(db_session: Session) -> None:
+async def init_db(db_session: AsyncSession) -> None:
     """
     Adds the first superuser to the database if it doesn't exist already.
     """
@@ -23,7 +23,7 @@ def init_db(db_session: Session) -> None:
     # following line:
     # Base.metadata.create_all(bind=engine)
 
-    user = crud.user.get_by_email(db_session, email=settings.FIRST_SUPERUSER)
+    user = await crud.user.get_by_email(db_session, email=settings.FIRST_SUPERUSER)
 
     if not user:
         user_in = schemas.UserCreate(
@@ -32,7 +32,7 @@ def init_db(db_session: Session) -> None:
             full_name=settings.FIRST_SUPERUSER_NAME,
             is_superuser=True,
         )
-        user = crud.user.create(db_session, obj_in=user_in)
+        user = await crud.user.create(db_session, obj_in=user_in)
         LOGGER.info(
             "Added first superuser to the database", email=settings.FIRST_SUPERUSER
         )

--- a/app/db/session.py
+++ b/app/db/session.py
@@ -2,14 +2,20 @@
 Provides an SQLAlchemy `Session` which can be used for accessing the database.
 """
 
-from sqlalchemy import create_engine
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 from sqlalchemy.orm import sessionmaker
 
 from app.core.config import settings
 
 assert settings.SQLALCHEMY_DATABASE_URI is not None
 
-engine = create_engine(
+engine = create_async_engine(
     settings.SQLALCHEMY_DATABASE_URI, pool_pre_ping=True, future=True
 )
-SessionLocal = sessionmaker(autoflush=False, bind=engine, future=True)
+SessionLocal = sessionmaker(
+    autoflush=False,
+    bind=engine,
+    expire_on_commit=False,
+    class_=AsyncSession,
+    future=True,
+)

--- a/app/initial_data.py
+++ b/app/initial_data.py
@@ -2,6 +2,7 @@
 Script to add initial data to database.
 """
 
+import asyncio
 import logging
 
 from app.db.init_db import init_db
@@ -12,24 +13,24 @@ logging.config.dictConfig(logging_dict_config)
 LOGGER = logging.getLogger("initial_data")
 
 
-def init() -> None:
+async def init() -> None:
     """
     Creates initial data in the database.
     """
 
-    db_session = SessionLocal()
-    init_db(db_session)
+    async with SessionLocal() as db_session:
+        await init_db(db_session)
 
 
-def main() -> None:
+async def main() -> None:
     """
     Driver function.
     """
 
     LOGGER.info("Creating initial data")
-    init()
+    await init()
     LOGGER.info("Initial data created")
 
 
 if __name__ == "__main__":
-    main()
+    asyncio.run(main())

--- a/app/models/question_order_item.py
+++ b/app/models/question_order_item.py
@@ -37,13 +37,16 @@ class QuestionOrderItem(Base):  # pylint: disable=too-few-public-methods
 
     # SQLAlchemy relationship.
     # This doesn't add an attribute/column to the table in the database, but provides an
-    # attribute in the model instance whose value is populated (by SQLAlchemy) when it
-    # is first accessed. The value is populated by using the foreign key and performing
-    # a suitable JOIN operation.
+    # attribute in the model instance whose value is populated (by SQLAlchemy) eagerly
+    # (we can't use lazy loading with async SQLAlchemy dialects). The value is populated
+    # by using the foreign key and performing a suitable JOIN operation.
     # In this case, `question` is an instance of `Question` which has the same `id` as
     # the `question_id` in `self`.
     question: Mapped["Question"] = relationship(
-        "Question", uselist=False, viewonly=True
+        "Question",
+        lazy="selectin",
+        uselist=False,
+        viewonly=True,
     )
 
     def __repr__(self) -> str:

--- a/app/pre_start.py
+++ b/app/pre_start.py
@@ -2,6 +2,7 @@
 Pre-start script to verify database connectivity.
 """
 
+import asyncio
 import logging
 
 from sqlalchemy import text
@@ -24,7 +25,7 @@ LOGGER = logging.getLogger("pre_start")
     before=before_log(LOGGER, logging.INFO),
     after=after_log(LOGGER, logging.WARN),
 )
-def verify_db_connectivity() -> None:
+async def verify_db_connectivity() -> None:
     """
     Verify database connectivity.
     """
@@ -32,24 +33,24 @@ def verify_db_connectivity() -> None:
     try:
         # Try to create a session and execute a statement to check if database is
         # available
-        db_session = SessionLocal()
-        db_session.execute(text("SELECT 1;"))
-        LOGGER.info("Database connection successful")
+        async with SessionLocal() as db_session:
+            await db_session.execute(text("SELECT 1;"))
+            LOGGER.info("Database connection successful")
 
     except Exception as exception:
         LOGGER.exception(exception)
         raise
 
 
-def main() -> None:
+async def main() -> None:
     """
     Driver function.
     """
 
     LOGGER.info("Initializing service")
-    verify_db_connectivity()
+    await verify_db_connectivity()
     LOGGER.info("Service finished initializing")
 
 
 if __name__ == "__main__":
-    main()
+    asyncio.run(main())

--- a/app/pre_start.py
+++ b/app/pre_start.py
@@ -35,7 +35,8 @@ async def verify_db_connectivity() -> None:
         # available
         async with SessionLocal() as db_session:
             await db_session.execute(text("SELECT 1;"))
-            LOGGER.info("Database connection successful")
+
+        LOGGER.info("Database connection successful")
 
     except Exception as exception:
         LOGGER.exception(exception)

--- a/app/tests/api/api_v1/test_login.py
+++ b/app/tests/api/api_v1/test_login.py
@@ -3,18 +3,23 @@
 
 from typing import Dict
 
-from fastapi.testclient import TestClient
+import pytest
+from httpx import AsyncClient
 
 from app.core.config import settings
 from app.tests.utils.utils import random_email, random_lower_string
 
+pytestmark = pytest.mark.asyncio
 
-def test_get_access_token(client: TestClient) -> None:
+
+async def test_get_access_token(client: AsyncClient) -> None:
     login_data = {
         "username": settings.FIRST_SUPERUSER,
         "password": settings.FIRST_SUPERUSER_PASSWORD,
     }
-    response = client.post(f"{settings.API_V1_STR}/login/access-token", data=login_data)
+    response = await client.post(
+        f"{settings.API_V1_STR}/login/access-token", data=login_data
+    )
     tokens = response.json()
 
     assert response.status_code == 200
@@ -22,20 +27,22 @@ def test_get_access_token(client: TestClient) -> None:
     assert tokens["access_token"]
 
 
-def test_not_get_access_token(client: TestClient) -> None:
+async def test_not_get_access_token(client: AsyncClient) -> None:
     login_data = {
         "username": random_email(),
         "password": random_lower_string(),
     }
-    response = client.post(f"{settings.API_V1_STR}/login/access-token", data=login_data)
+    response = await client.post(
+        f"{settings.API_V1_STR}/login/access-token", data=login_data
+    )
 
     assert response.status_code == 400
 
 
-def test_use_access_token(
-    client: TestClient, superuser_token_headers: Dict[str, str]
+async def test_use_access_token(
+    client: AsyncClient, superuser_token_headers: Dict[str, str]
 ) -> None:
-    response = client.post(
+    response = await client.post(
         f"{settings.API_V1_STR}/login/test-token",
         headers=superuser_token_headers,
     )

--- a/app/tests/api/api_v1/test_question_order_items.py
+++ b/app/tests/api/api_v1/test_question_order_items.py
@@ -3,8 +3,9 @@
 
 from typing import Dict
 
-from fastapi.testclient import TestClient
-from sqlalchemy.orm import Session
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from app import crud
 from app.core.config import settings
@@ -12,16 +13,20 @@ from app.tests.utils.question import create_random_question
 from app.tests.utils.question_order_item import create_random_question_order_item
 from app.tests.utils.utils import random_int
 
+pytestmark = pytest.mark.asyncio
 
-def test_create_question_order_item(
-    client: TestClient, superuser_token_headers: Dict[str, str], db_session: Session
+
+async def test_create_question_order_item(
+    client: AsyncClient,
+    superuser_token_headers: Dict[str, str],
+    db_session: AsyncSession,
 ) -> None:
-    question = create_random_question(db_session)
+    question = await create_random_question(db_session)
     assert question.id  # Required for mypy
     question_id = question.id
     question_number = random_int()
     data = {"question_id": question_id, "question_number": question_number}
-    response = client.post(
+    response = await client.post(
         f"{settings.API_V1_STR}/questions_order/",
         headers=superuser_token_headers,
         json=data,
@@ -30,10 +35,10 @@ def test_create_question_order_item(
     assert 200 <= response.status_code < 300
 
     created_item = response.json()
-    question_order_item1 = crud.question_order_item.get_by_question_id(
+    question_order_item1 = await crud.question_order_item.get_by_question_id(
         db_session, question_id=question_id
     )
-    question_order_item2 = crud.question_order_item.get_by_question_number(
+    question_order_item2 = await crud.question_order_item.get_by_question_number(
         db_session, question_number=question_number
     )
 
@@ -47,14 +52,16 @@ def test_create_question_order_item(
     assert question_order_item1.dict() == question_order_item2.dict()
 
 
-def test_create_question_order_item_existing_question_id(
-    client: TestClient, superuser_token_headers: Dict[str, str], db_session: Session
+async def test_create_question_order_item_existing_question_id(
+    client: AsyncClient,
+    superuser_token_headers: Dict[str, str],
+    db_session: AsyncSession,
 ) -> None:
-    question_order_item = create_random_question_order_item(db_session)
+    question_order_item = await create_random_question_order_item(db_session)
     question_id = question_order_item.question_id
     question_number = random_int()
     data = {"question_id": question_id, "question_number": question_number}
-    response = client.post(
+    response = await client.post(
         f"{settings.API_V1_STR}/questions_order/",
         headers=superuser_token_headers,
         json=data,
@@ -63,15 +70,17 @@ def test_create_question_order_item_existing_question_id(
     assert response.status_code == 400
 
 
-def test_create_question_order_item_existing_question_number(
-    client: TestClient, superuser_token_headers: Dict[str, str], db_session: Session
+async def test_create_question_order_item_existing_question_number(
+    client: AsyncClient,
+    superuser_token_headers: Dict[str, str],
+    db_session: AsyncSession,
 ) -> None:
-    question = create_random_question(db_session)
+    question = await create_random_question(db_session)
     question_id = question.id
-    question_order_item = create_random_question_order_item(db_session)
+    question_order_item = await create_random_question_order_item(db_session)
     question_number = question_order_item.question_number
     data = {"question_id": question_id, "question_number": question_number}
-    response = client.post(
+    response = await client.post(
         f"{settings.API_V1_STR}/questions_order/",
         headers=superuser_token_headers,
         json=data,
@@ -80,13 +89,13 @@ def test_create_question_order_item_existing_question_number(
     assert response.status_code == 400
 
 
-def test_create_question_order_item_not_existing_question(
-    client: TestClient, superuser_token_headers: Dict[str, str]
+async def test_create_question_order_item_not_existing_question(
+    client: AsyncClient, superuser_token_headers: Dict[str, str]
 ) -> None:
     question_id = -1
     question_number = random_int()
     data = {"question_id": question_id, "question_number": question_number}
-    response = client.post(
+    response = await client.post(
         f"{settings.API_V1_STR}/questions_order/",
         headers=superuser_token_headers,
         json=data,
@@ -95,12 +104,14 @@ def test_create_question_order_item_not_existing_question(
     assert response.status_code == 404
 
 
-def test_get_existing_question_order_item(
-    client: TestClient, superuser_token_headers: Dict[str, str], db_session: Session
+async def test_get_existing_question_order_item(
+    client: AsyncClient,
+    superuser_token_headers: Dict[str, str],
+    db_session: AsyncSession,
 ) -> None:
-    question_order_item = create_random_question_order_item(db_session)
+    question_order_item = await create_random_question_order_item(db_session)
     question_order_item_id = question_order_item.id
-    response = client.get(
+    response = await client.get(
         f"{settings.API_V1_STR}/questions_order/{question_order_item_id}",
         headers=superuser_token_headers,
     )
@@ -109,7 +120,7 @@ def test_get_existing_question_order_item(
 
     api_question_order_item = response.json()
     assert question_order_item.question_id
-    existing_question_order_item = crud.question_order_item.get_by_question_id(
+    existing_question_order_item = await crud.question_order_item.get_by_question_id(
         db_session, question_id=question_order_item.question_id
     )
 
@@ -124,11 +135,11 @@ def test_get_existing_question_order_item(
     )
 
 
-def test_get_not_existing_question_order_item(
-    client: TestClient, superuser_token_headers: Dict[str, str]
+async def test_get_not_existing_question_order_item(
+    client: AsyncClient, superuser_token_headers: Dict[str, str]
 ) -> None:
     question_order_item_id = -1
-    response = client.get(
+    response = await client.get(
         f"{settings.API_V1_STR}/questions_order/{question_order_item_id}",
         headers=superuser_token_headers,
     )
@@ -136,14 +147,16 @@ def test_get_not_existing_question_order_item(
     assert response.status_code == 404
 
 
-def test_retrieve_question_order_items(
-    client: TestClient, superuser_token_headers: Dict[str, str], db_session: Session
+async def test_retrieve_question_order_items(
+    client: AsyncClient,
+    superuser_token_headers: Dict[str, str],
+    db_session: AsyncSession,
 ) -> None:
-    create_random_question_order_item(db_session)
-    create_random_question_order_item(db_session)
-    create_random_question_order_item(db_session)
+    await create_random_question_order_item(db_session)
+    await create_random_question_order_item(db_session)
+    await create_random_question_order_item(db_session)
 
-    response = client.get(
+    response = await client.get(
         f"{settings.API_V1_STR}/questions_order/", headers=superuser_token_headers
     )
     all_items = response.json()
@@ -154,14 +167,16 @@ def test_retrieve_question_order_items(
         assert "question_number" in item
 
 
-def test_update_existing_question_order_item_new_question_number(
-    client: TestClient, superuser_token_headers: Dict[str, str], db_session: Session
+async def test_update_existing_question_order_item_new_question_number(
+    client: AsyncClient,
+    superuser_token_headers: Dict[str, str],
+    db_session: AsyncSession,
 ) -> None:
-    question_order_item = create_random_question_order_item(db_session)
+    question_order_item = await create_random_question_order_item(db_session)
     question_order_item_id = question_order_item.id
     new_question_number = random_int()
     data = {"question_number": new_question_number}
-    response = client.put(
+    response = await client.put(
         f"{settings.API_V1_STR}/questions_order/{question_order_item_id}",
         headers=superuser_token_headers,
         json=data,
@@ -177,15 +192,17 @@ def test_update_existing_question_order_item_new_question_number(
     assert updated_question_order_item["question_number"] == new_question_number
 
 
-def test_update_existing_question_order_item_new_question_id(
-    client: TestClient, superuser_token_headers: Dict[str, str], db_session: Session
+async def test_update_existing_question_order_item_new_question_id(
+    client: AsyncClient,
+    superuser_token_headers: Dict[str, str],
+    db_session: AsyncSession,
 ) -> None:
-    question_order_item = create_random_question_order_item(db_session)
+    question_order_item = await create_random_question_order_item(db_session)
     question_order_item_id = question_order_item.id
-    question = create_random_question(db_session)
+    question = await create_random_question(db_session)
     new_question_id = question.id
     data = {"question_id": new_question_id}
-    response = client.put(
+    response = await client.put(
         f"{settings.API_V1_STR}/questions_order/{question_order_item_id}",
         headers=superuser_token_headers,
         json=data,
@@ -201,14 +218,16 @@ def test_update_existing_question_order_item_new_question_id(
     assert updated_question_order_item["question_id"] == new_question_id
 
 
-def test_update_existing_question_order_item_not_existing_question_id(
-    client: TestClient, superuser_token_headers: Dict[str, str], db_session: Session
+async def test_update_existing_question_order_item_not_existing_question_id(
+    client: AsyncClient,
+    superuser_token_headers: Dict[str, str],
+    db_session: AsyncSession,
 ) -> None:
-    question_order_item = create_random_question_order_item(db_session)
+    question_order_item = await create_random_question_order_item(db_session)
     question_order_item_id = question_order_item.id
     new_question_id = -1
     data = {"question_id": new_question_id}
-    response = client.put(
+    response = await client.put(
         f"{settings.API_V1_STR}/questions_order/{question_order_item_id}",
         headers=superuser_token_headers,
         json=data,
@@ -217,13 +236,13 @@ def test_update_existing_question_order_item_not_existing_question_id(
     assert response.status_code == 404
 
 
-def test_update_not_existing_question_order_item(
-    client: TestClient, superuser_token_headers: Dict[str, str]
+async def test_update_not_existing_question_order_item(
+    client: AsyncClient, superuser_token_headers: Dict[str, str]
 ) -> None:
     question_order_item_id = -1
     new_question_number = random_int()
     data = {"question_number": new_question_number}
-    response = client.put(
+    response = await client.put(
         f"{settings.API_V1_STR}/questions_order/{question_order_item_id}",
         headers=superuser_token_headers,
         json=data,
@@ -232,17 +251,19 @@ def test_update_not_existing_question_order_item(
     assert response.status_code == 404
 
 
-def test_update_existing_question_order_item_duplicate_question_number(
-    client: TestClient, superuser_token_headers: Dict[str, str], db_session: Session
+async def test_update_existing_question_order_item_duplicate_question_number(
+    client: AsyncClient,
+    superuser_token_headers: Dict[str, str],
+    db_session: AsyncSession,
 ) -> None:
-    question_order_item = create_random_question_order_item(db_session)
+    question_order_item = await create_random_question_order_item(db_session)
     question_order_item_id = question_order_item.id
 
-    question_order_item2 = create_random_question_order_item(db_session)
+    question_order_item2 = await create_random_question_order_item(db_session)
     new_question_number = question_order_item2.question_number
 
     data = {"question_number": new_question_number}
-    response = client.put(
+    response = await client.put(
         f"{settings.API_V1_STR}/questions_order/{question_order_item_id}",
         headers=superuser_token_headers,
         json=data,
@@ -251,17 +272,19 @@ def test_update_existing_question_order_item_duplicate_question_number(
     assert response.status_code == 400
 
 
-def test_update_existing_question_order_item_duplicate_question_id(
-    client: TestClient, superuser_token_headers: Dict[str, str], db_session: Session
+async def test_update_existing_question_order_item_duplicate_question_id(
+    client: AsyncClient,
+    superuser_token_headers: Dict[str, str],
+    db_session: AsyncSession,
 ) -> None:
-    question_order_item = create_random_question_order_item(db_session)
+    question_order_item = await create_random_question_order_item(db_session)
     question_order_item_id = question_order_item.id
 
-    question_order_item2 = create_random_question_order_item(db_session)
+    question_order_item2 = await create_random_question_order_item(db_session)
     new_question_id = question_order_item2.question_id
 
     data = {"question_id": new_question_id}
-    response = client.put(
+    response = await client.put(
         f"{settings.API_V1_STR}/questions_order/{question_order_item_id}",
         headers=superuser_token_headers,
         json=data,
@@ -270,12 +293,14 @@ def test_update_existing_question_order_item_duplicate_question_id(
     assert response.status_code == 400
 
 
-def test_delete_existing_question_order_item(
-    client: TestClient, superuser_token_headers: Dict[str, str], db_session: Session
+async def test_delete_existing_question_order_item(
+    client: AsyncClient,
+    superuser_token_headers: Dict[str, str],
+    db_session: AsyncSession,
 ) -> None:
-    question_order_item = create_random_question_order_item(db_session)
+    question_order_item = await create_random_question_order_item(db_session)
     question_order_item_id = question_order_item.id
-    response = client.delete(
+    response = await client.delete(
         f"{settings.API_V1_STR}/questions_order/{question_order_item_id}",
         headers=superuser_token_headers,
     )
@@ -283,11 +308,11 @@ def test_delete_existing_question_order_item(
     assert 200 <= response.status_code < 300
 
 
-def test_delete_not_existing_question_order_item(
-    client: TestClient, superuser_token_headers: Dict[str, str]
+async def test_delete_not_existing_question_order_item(
+    client: AsyncClient, superuser_token_headers: Dict[str, str]
 ) -> None:
     question_order_item_id = -1
-    response = client.delete(
+    response = await client.delete(
         f"{settings.API_V1_STR}/questions_order/{question_order_item_id}",
         headers=superuser_token_headers,
     )

--- a/app/tests/api/api_v1/test_questions.py
+++ b/app/tests/api/api_v1/test_questions.py
@@ -3,8 +3,9 @@
 
 from typing import Dict
 
-from fastapi.testclient import TestClient
-from sqlalchemy.orm import Session
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from app import crud
 from app.core.config import settings
@@ -18,15 +19,17 @@ from app.tests.utils.question import (
 )
 from app.tests.utils.utils import random_lower_string
 
+pytestmark = pytest.mark.asyncio
 
-def test_create_question_accept_png(
-    client: TestClient, superuser_token_headers: Dict[str, str]
+
+async def test_create_question_accept_png(
+    client: AsyncClient, superuser_token_headers: Dict[str, str]
 ) -> None:
     data = {"answer": random_lower_string()}
     files = {
         "image": (random_lower_string(), horse_image_contents(), png_content_type())
     }
-    response = client.post(
+    response = await client.post(
         f"{settings.API_V1_STR}/questions/",
         headers=superuser_token_headers,
         data=data,
@@ -36,14 +39,14 @@ def test_create_question_accept_png(
     assert 200 <= response.status_code < 300
 
 
-def test_create_question_accept_jpeg(
-    client: TestClient, superuser_token_headers: Dict[str, str]
+async def test_create_question_accept_jpeg(
+    client: AsyncClient, superuser_token_headers: Dict[str, str]
 ) -> None:
     data = {"answer": random_lower_string()}
     files = {
         "image": (random_lower_string(), horse_image_contents(), jpg_content_type())
     }
-    response = client.post(
+    response = await client.post(
         f"{settings.API_V1_STR}/questions/",
         headers=superuser_token_headers,
         data=data,
@@ -53,14 +56,14 @@ def test_create_question_accept_jpeg(
     assert 200 <= response.status_code < 300
 
 
-def test_create_question_not_accept_gif(
-    client: TestClient, superuser_token_headers: Dict[str, str]
+async def test_create_question_not_accept_gif(
+    client: AsyncClient, superuser_token_headers: Dict[str, str]
 ) -> None:
     data = {"answer": random_lower_string()}
     files = {
         "image": (random_lower_string(), horse_image_contents(), gif_content_type())
     }
-    response = client.post(
+    response = await client.post(
         f"{settings.API_V1_STR}/questions/",
         headers=superuser_token_headers,
         data=data,
@@ -70,15 +73,17 @@ def test_create_question_not_accept_gif(
     assert response.status_code == 400
 
 
-def test_create_question_new_answer(
-    client: TestClient, superuser_token_headers: Dict[str, str], db_session: Session
+async def test_create_question_new_answer(
+    client: AsyncClient,
+    superuser_token_headers: Dict[str, str],
+    db_session: AsyncSession,
 ) -> None:
     answer = random_lower_string()
     data = {"answer": answer}
     files = {
         "image": (random_lower_string(), horse_image_contents(), png_content_type())
     }
-    response = client.post(
+    response = await client.post(
         f"{settings.API_V1_STR}/questions/",
         headers=superuser_token_headers,
         data=data,
@@ -88,7 +93,7 @@ def test_create_question_new_answer(
     assert 200 <= response.status_code < 300
 
     created_question = response.json()
-    question = crud.question.get_by_answer(db_session, answer=answer)
+    question = await crud.question.get_by_answer(db_session, answer=answer)
 
     assert question
     assert "id" in created_question
@@ -96,8 +101,10 @@ def test_create_question_new_answer(
     assert question.answer == created_question["answer"]
 
 
-def test_create_question_existing_answer(
-    client: TestClient, superuser_token_headers: Dict[str, str], db_session: Session
+async def test_create_question_existing_answer(
+    client: AsyncClient,
+    superuser_token_headers: Dict[str, str],
+    db_session: AsyncSession,
 ) -> None:
     answer = random_lower_string()
     question_in = QuestionCreate(
@@ -105,12 +112,12 @@ def test_create_question_existing_answer(
         content=horse_image_contents(),
         content_type=png_content_type(),
     )
-    crud.question.create(db_session, obj_in=question_in)
+    await crud.question.create(db_session, obj_in=question_in)
     data = {"answer": answer}
     files = {
         "image": (random_lower_string(), horse_image_contents(), png_content_type())
     }
-    response = client.post(
+    response = await client.post(
         f"{settings.API_V1_STR}/questions/",
         headers=superuser_token_headers,
         data=data,
@@ -120,12 +127,14 @@ def test_create_question_existing_answer(
     assert response.status_code == 400
 
 
-def test_get_existing_question(
-    client: TestClient, superuser_token_headers: Dict[str, str], db_session: Session
+async def test_get_existing_question(
+    client: AsyncClient,
+    superuser_token_headers: Dict[str, str],
+    db_session: AsyncSession,
 ) -> None:
-    question = create_random_question(db_session)
+    question = await create_random_question(db_session)
     question_id = question.id
-    response = client.get(
+    response = await client.get(
         f"{settings.API_V1_STR}/questions/{question_id}",
         headers=superuser_token_headers,
     )
@@ -134,19 +143,23 @@ def test_get_existing_question(
 
     api_question = response.json()
     assert question.answer
-    existing_question = crud.question.get_by_answer(db_session, answer=question.answer)
+    existing_question = await crud.question.get_by_answer(
+        db_session, answer=question.answer
+    )
 
     assert existing_question
     assert existing_question.answer == api_question["answer"]
 
 
-def test_get_existing_question_image(
-    client: TestClient, superuser_token_headers: Dict[str, str], db_session: Session
+async def test_get_existing_question_image(
+    client: AsyncClient,
+    superuser_token_headers: Dict[str, str],
+    db_session: AsyncSession,
 ) -> None:
-    question = create_random_question(db_session)
+    question = await create_random_question(db_session)
     question_id = question.id
     params = {"image": True}
-    response = client.get(
+    response = await client.get(
         f"{settings.API_V1_STR}/questions/{question_id}",
         headers=superuser_token_headers,
         params=params,
@@ -159,11 +172,11 @@ def test_get_existing_question_image(
     assert response.headers[content_type_header] == png_content_type()
 
 
-def test_get_not_existing_question(
-    client: TestClient, superuser_token_headers: Dict[str, str]
+async def test_get_not_existing_question(
+    client: AsyncClient, superuser_token_headers: Dict[str, str]
 ) -> None:
     question_id = -1
-    response = client.get(
+    response = await client.get(
         f"{settings.API_V1_STR}/questions/{question_id}",
         headers=superuser_token_headers,
     )
@@ -171,14 +184,16 @@ def test_get_not_existing_question(
     assert response.status_code == 404
 
 
-def test_retrieve_questions(
-    client: TestClient, superuser_token_headers: Dict[str, str], db_session: Session
+async def test_retrieve_questions(
+    client: AsyncClient,
+    superuser_token_headers: Dict[str, str],
+    db_session: AsyncSession,
 ) -> None:
-    create_random_question(db_session)
-    create_random_question(db_session)
-    create_random_question(db_session)
+    await create_random_question(db_session)
+    await create_random_question(db_session)
+    await create_random_question(db_session)
 
-    response = client.get(
+    response = await client.get(
         f"{settings.API_V1_STR}/questions/", headers=superuser_token_headers
     )
     all_questions = response.json()
@@ -188,14 +203,16 @@ def test_retrieve_questions(
         assert "answer" in item
 
 
-def test_update_existing_question(
-    client: TestClient, superuser_token_headers: Dict[str, str], db_session: Session
+async def test_update_existing_question(
+    client: AsyncClient,
+    superuser_token_headers: Dict[str, str],
+    db_session: AsyncSession,
 ) -> None:
-    question = create_random_question(db_session)
+    question = await create_random_question(db_session)
     question_id = question.id
     new_answer = random_lower_string()
     data = {"answer": new_answer}
-    response = client.patch(
+    response = await client.patch(
         f"{settings.API_V1_STR}/questions/{question_id}",
         headers=superuser_token_headers,
         json=data,
@@ -211,13 +228,13 @@ def test_update_existing_question(
     assert updated_question["answer"] == new_answer
 
 
-def test_update_not_existing_question(
-    client: TestClient, superuser_token_headers: Dict[str, str]
+async def test_update_not_existing_question(
+    client: AsyncClient, superuser_token_headers: Dict[str, str]
 ) -> None:
     question_id = -1
     new_answer = random_lower_string()
     data = {"answer": new_answer}
-    response = client.patch(
+    response = await client.patch(
         f"{settings.API_V1_STR}/questions/{question_id}",
         headers=superuser_token_headers,
         json=data,
@@ -226,15 +243,17 @@ def test_update_not_existing_question(
     assert response.status_code == 404
 
 
-def test_update_existing_question_duplicate_answer(
-    client: TestClient, superuser_token_headers: Dict[str, str], db_session: Session
+async def test_update_existing_question_duplicate_answer(
+    client: AsyncClient,
+    superuser_token_headers: Dict[str, str],
+    db_session: AsyncSession,
 ) -> None:
-    question = create_random_question(db_session)
-    question2 = create_random_question(db_session)
+    question = await create_random_question(db_session)
+    question2 = await create_random_question(db_session)
     question_id = question.id
     new_answer = question2.answer
     data = {"answer": new_answer}
-    response = client.patch(
+    response = await client.patch(
         f"{settings.API_V1_STR}/questions/{question_id}",
         headers=superuser_token_headers,
         json=data,
@@ -243,12 +262,14 @@ def test_update_existing_question_duplicate_answer(
     assert response.status_code == 400
 
 
-def test_delete_existing_question(
-    client: TestClient, superuser_token_headers: Dict[str, str], db_session: Session
+async def test_delete_existing_question(
+    client: AsyncClient,
+    superuser_token_headers: Dict[str, str],
+    db_session: AsyncSession,
 ) -> None:
-    question = create_random_question(db_session)
+    question = await create_random_question(db_session)
     question_id = question.id
-    response = client.delete(
+    response = await client.delete(
         f"{settings.API_V1_STR}/questions/{question_id}",
         headers=superuser_token_headers,
     )
@@ -256,11 +277,11 @@ def test_delete_existing_question(
     assert 200 <= response.status_code < 300
 
 
-def test_delete_not_existing_question(
-    client: TestClient, superuser_token_headers: Dict[str, str]
+async def test_delete_not_existing_question(
+    client: AsyncClient, superuser_token_headers: Dict[str, str]
 ) -> None:
     question_id = -1
-    response = client.delete(
+    response = await client.delete(
         f"{settings.API_V1_STR}/questions/{question_id}",
         headers=superuser_token_headers,
     )

--- a/app/tests/api/api_v1/test_users.py
+++ b/app/tests/api/api_v1/test_users.py
@@ -4,8 +4,8 @@
 from typing import Dict
 
 import pytest
-from fastapi.testclient import TestClient
-from sqlalchemy.orm import Session
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from app import crud
 from app.core.config import settings
@@ -15,11 +15,13 @@ from app.tests.utils.question_order_item import create_random_question_order_ite
 from app.tests.utils.user import authentication_token_from_email, create_random_user
 from app.tests.utils.utils import random_email, random_int, random_lower_string
 
+pytestmark = pytest.mark.asyncio
 
-def test_get_users_superuser_me(
-    client: TestClient, superuser_token_headers: Dict[str, str]
+
+async def test_get_users_superuser_me(
+    client: AsyncClient, superuser_token_headers: Dict[str, str]
 ) -> None:
-    response = client.get(
+    response = await client.get(
         f"{settings.API_V1_STR}/users/me", headers=superuser_token_headers
     )
     current_user = response.json()
@@ -29,10 +31,10 @@ def test_get_users_superuser_me(
     assert current_user["email"] == settings.FIRST_SUPERUSER
 
 
-def test_get_users_normal_user_me(
-    client: TestClient, normal_user_token_headers: Dict[str, str]
+async def test_get_users_normal_user_me(
+    client: AsyncClient, normal_user_token_headers: Dict[str, str]
 ) -> None:
-    response = client.get(
+    response = await client.get(
         f"{settings.API_V1_STR}/users/me", headers=normal_user_token_headers
     )
     current_user = response.json()
@@ -42,14 +44,16 @@ def test_get_users_normal_user_me(
     assert current_user["email"] == settings.EMAIL_TEST_USER
 
 
-def test_create_user_new_email(
-    client: TestClient, superuser_token_headers: Dict[str, str], db_session: Session
+async def test_create_user_new_email(
+    client: AsyncClient,
+    superuser_token_headers: Dict[str, str],
+    db_session: AsyncSession,
 ) -> None:
     username = random_email()
     password = random_lower_string()
     full_name = random_lower_string()
     data = {"email": username, "password": password, "full_name": full_name}
-    response = client.post(
+    response = await client.post(
         f"{settings.API_V1_STR}/users/",
         headers=superuser_token_headers,
         json=data,
@@ -58,18 +62,20 @@ def test_create_user_new_email(
     assert 200 <= response.status_code < 300
 
     created_user = response.json()
-    user = crud.user.get_by_email(db_session, email=username)
+    user = await crud.user.get_by_email(db_session, email=username)
 
     assert user
     assert user.email == created_user["email"]
 
 
-def test_get_existing_user(
-    client: TestClient, superuser_token_headers: Dict[str, str], db_session: Session
+async def test_get_existing_user(
+    client: AsyncClient,
+    superuser_token_headers: Dict[str, str],
+    db_session: AsyncSession,
 ) -> None:
-    user = create_random_user(db_session)
+    user = await create_random_user(db_session)
     user_id = user.id
-    response = client.get(
+    response = await client.get(
         f"{settings.API_V1_STR}/users/{user_id}",
         headers=superuser_token_headers,
     )
@@ -78,17 +84,17 @@ def test_get_existing_user(
 
     api_user = response.json()
     assert user.email
-    existing_user = crud.user.get_by_email(db_session, email=user.email)
+    existing_user = await crud.user.get_by_email(db_session, email=user.email)
 
     assert existing_user
     assert existing_user.email == api_user["email"]
 
 
-def test_get_not_existing_user(
-    client: TestClient, superuser_token_headers: Dict[str, str]
+async def test_get_not_existing_user(
+    client: AsyncClient, superuser_token_headers: Dict[str, str]
 ) -> None:
     user_id = -1
-    response = client.get(
+    response = await client.get(
         f"{settings.API_V1_STR}/users/{user_id}",
         headers=superuser_token_headers,
     )
@@ -96,13 +102,15 @@ def test_get_not_existing_user(
     assert response.status_code == 404
 
 
-def test_get_current_user_normal_user(
-    client: TestClient, normal_user_token_headers: Dict[str, str], db_session: Session
+async def test_get_current_user_normal_user(
+    client: AsyncClient,
+    normal_user_token_headers: Dict[str, str],
+    db_session: AsyncSession,
 ) -> None:
-    user = crud.user.get_by_email(db_session, email=settings.EMAIL_TEST_USER)
+    user = await crud.user.get_by_email(db_session, email=settings.EMAIL_TEST_USER)
     assert user
     user_id = user.id
-    response = client.get(
+    response = await client.get(
         f"{settings.API_V1_STR}/users/{user_id}",
         headers=normal_user_token_headers,
     )
@@ -113,13 +121,15 @@ def test_get_current_user_normal_user(
     assert current_user["email"] == settings.EMAIL_TEST_USER
 
 
-def test_get_another_user_normal_user(
-    client: TestClient, normal_user_token_headers: Dict[str, str], db_session: Session
+async def test_get_another_user_normal_user(
+    client: AsyncClient,
+    normal_user_token_headers: Dict[str, str],
+    db_session: AsyncSession,
 ) -> None:
-    user = crud.user.get_by_email(db_session, email=settings.EMAIL_TEST_USER)
+    user = await crud.user.get_by_email(db_session, email=settings.EMAIL_TEST_USER)
     assert user and user.id
     user_id = user.id - 1  # Any user ID other than current user
-    response = client.get(
+    response = await client.get(
         f"{settings.API_V1_STR}/users/{user_id}",
         headers=normal_user_token_headers,
     )
@@ -127,16 +137,18 @@ def test_get_another_user_normal_user(
     assert response.status_code == 400
 
 
-def test_create_user_existing_username(
-    client: TestClient, superuser_token_headers: Dict[str, str], db_session: Session
+async def test_create_user_existing_username(
+    client: AsyncClient,
+    superuser_token_headers: Dict[str, str],
+    db_session: AsyncSession,
 ) -> None:
     username = random_email()
     password = random_lower_string()
     full_name = random_lower_string()
     user_in = UserCreate(email=username, password=password, full_name=full_name)
-    crud.user.create(db_session, obj_in=user_in)
+    await crud.user.create(db_session, obj_in=user_in)
     data = {"email": username, "password": password, "full_name": full_name}
-    response = client.post(
+    response = await client.post(
         f"{settings.API_V1_STR}/users/",
         headers=superuser_token_headers,
         json=data,
@@ -147,14 +159,14 @@ def test_create_user_existing_username(
     assert "_id" not in created_user
 
 
-def test_create_user_by_normal_user(
-    client: TestClient, normal_user_token_headers: Dict[str, str]
+async def test_create_user_by_normal_user(
+    client: AsyncClient, normal_user_token_headers: Dict[str, str]
 ) -> None:
     username = random_email()
     password = random_lower_string()
     full_name = random_lower_string()
     data = {"email": username, "password": password, "full_name": full_name}
-    response = client.post(
+    response = await client.post(
         f"{settings.API_V1_STR}/users/",
         headers=normal_user_token_headers,
         json=data,
@@ -163,14 +175,16 @@ def test_create_user_by_normal_user(
     assert response.status_code == 400
 
 
-def test_retrieve_users(
-    client: TestClient, superuser_token_headers: Dict[str, str], db_session: Session
+async def test_retrieve_users(
+    client: AsyncClient,
+    superuser_token_headers: Dict[str, str],
+    db_session: AsyncSession,
 ) -> None:
-    create_random_user(db_session)
-    create_random_user(db_session)
-    create_random_user(db_session)
+    await create_random_user(db_session)
+    await create_random_user(db_session)
+    await create_random_user(db_session)
 
-    response = client.get(
+    response = await client.get(
         f"{settings.API_V1_STR}/users/", headers=superuser_token_headers
     )
     all_users = response.json()
@@ -180,15 +194,15 @@ def test_retrieve_users(
         assert "email" in user
 
 
-def test_update_user_normal_user_me(
-    client: TestClient, normal_user_token_headers: Dict[str, str]
+async def test_update_user_normal_user_me(
+    client: AsyncClient, normal_user_token_headers: Dict[str, str]
 ) -> None:
     data = {
         "email": random_email(),
         "password": random_lower_string(),
         "full_name": random_lower_string(),
     }
-    response = client.put(
+    response = await client.put(
         f"{settings.API_V1_STR}/users/me",
         headers=normal_user_token_headers,
         json=data,
@@ -204,13 +218,13 @@ def test_update_user_normal_user_me(
 @pytest.mark.skipif(
     not settings.USERS_OPEN_REGISTRATION, reason="Open user registration disabled"
 )
-def test_create_user_open(client: TestClient) -> None:
+async def test_create_user_open(client: AsyncClient) -> None:
     data = {
         "email": random_email(),
         "password": random_lower_string(),
         "full_name": random_lower_string(),
     }
-    response = client.post(
+    response = await client.post(
         f"{settings.API_V1_STR}/users/open",
         json=data,
     )
@@ -225,16 +239,16 @@ def test_create_user_open(client: TestClient) -> None:
 @pytest.mark.skipif(
     not settings.USERS_OPEN_REGISTRATION, reason="Open user registration disabled"
 )
-def test_create_user_open_existing_username(
-    client: TestClient, db_session: Session
+async def test_create_user_open_existing_username(
+    client: AsyncClient, db_session: AsyncSession
 ) -> None:
     username = random_email()
     password = random_lower_string()
     full_name = random_lower_string()
     user_in = UserCreate(email=username, password=password, full_name=full_name)
-    crud.user.create(db_session, obj_in=user_in)
+    await crud.user.create(db_session, obj_in=user_in)
     data = {"email": username, "password": password, "full_name": full_name}
-    response = client.post(
+    response = await client.post(
         f"{settings.API_V1_STR}/users/open",
         json=data,
     )
@@ -242,16 +256,18 @@ def test_create_user_open_existing_username(
     assert response.status_code == 400
 
 
-def test_update_user_existing_user(
-    client: TestClient, superuser_token_headers: Dict[str, str], db_session: Session
+async def test_update_user_existing_user(
+    client: AsyncClient,
+    superuser_token_headers: Dict[str, str],
+    db_session: AsyncSession,
 ) -> None:
-    user = create_random_user(db_session)
+    user = await create_random_user(db_session)
     data = {
         "email": random_email(),
         "full_name": random_lower_string(),
         "is_superuser": True,
     }
-    response = client.put(
+    response = await client.put(
         f"{settings.API_V1_STR}/users/{user.id}",
         headers=superuser_token_headers,
         json=data,
@@ -264,8 +280,8 @@ def test_update_user_existing_user(
     assert api_user["full_name"] == data["full_name"]
 
 
-def test_update_user_not_existing_user(
-    client: TestClient, superuser_token_headers: Dict[str, str]
+async def test_update_user_not_existing_user(
+    client: AsyncClient, superuser_token_headers: Dict[str, str]
 ) -> None:
     user_id = -1
     data = {
@@ -274,7 +290,7 @@ def test_update_user_not_existing_user(
         "full_name": random_lower_string(),
         "is_superuser": True,
     }
-    response = client.put(
+    response = await client.put(
         f"{settings.API_V1_STR}/users/{user_id}",
         headers=superuser_token_headers,
         json=data,
@@ -283,12 +299,14 @@ def test_update_user_not_existing_user(
     assert response.status_code == 404
 
 
-def test_delete_user_existing_user(
-    client: TestClient, superuser_token_headers: Dict[str, str], db_session: Session
+async def test_delete_user_existing_user(
+    client: AsyncClient,
+    superuser_token_headers: Dict[str, str],
+    db_session: AsyncSession,
 ) -> None:
-    user = create_random_user(db_session)
+    user = await create_random_user(db_session)
     user_id = user.id
-    response = client.delete(
+    response = await client.delete(
         f"{settings.API_V1_STR}/users/{user_id}",
         headers=superuser_token_headers,
     )
@@ -296,11 +314,11 @@ def test_delete_user_existing_user(
     assert 200 <= response.status_code < 300
 
 
-def test_delete_user_not_existing_user(
-    client: TestClient, superuser_token_headers: Dict[str, str]
+async def test_delete_user_not_existing_user(
+    client: AsyncClient, superuser_token_headers: Dict[str, str]
 ) -> None:
     user_id = -1
-    response = client.delete(
+    response = await client.delete(
         f"{settings.API_V1_STR}/users/{user_id}",
         headers=superuser_token_headers,
     )
@@ -308,18 +326,18 @@ def test_delete_user_not_existing_user(
     assert response.status_code == 404
 
 
-def test_get_question(client: TestClient, db_session: Session) -> None:
-    question_order_item = create_random_question_order_item(db_session)
+async def test_get_question(client: AsyncClient, db_session: AsyncSession) -> None:
+    question_order_item = await create_random_question_order_item(db_session)
     question_number = question_order_item.question_number
-    user = create_random_user(db_session)
+    user = await create_random_user(db_session)
     user_in_update = UserUpdate(question_number=question_number)
-    user = crud.user.update(db_session, db_obj=user, obj_in=user_in_update)
+    user = await crud.user.update(db_session, db_obj=user, obj_in=user_in_update)
     assert user.email  # Required for mypy
-    normal_user_token_headers = authentication_token_from_email(
+    normal_user_token_headers = await authentication_token_from_email(
         client=client, email=user.email, db_session=db_session
     )
 
-    response = client.get(
+    response = await client.get(
         f"{settings.API_V1_STR}/users/question", headers=normal_user_token_headers
     )
 
@@ -331,19 +349,21 @@ def test_get_question(client: TestClient, db_session: Session) -> None:
     assert "content_type" in question_data
 
 
-def test_get_question_image(client: TestClient, db_session: Session) -> None:
-    question_order_item = create_random_question_order_item(db_session)
+async def test_get_question_image(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    question_order_item = await create_random_question_order_item(db_session)
     question_number = question_order_item.question_number
-    user = create_random_user(db_session)
+    user = await create_random_user(db_session)
     user_in_update = UserUpdate(question_number=question_number)
-    user = crud.user.update(db_session, db_obj=user, obj_in=user_in_update)
+    user = await crud.user.update(db_session, db_obj=user, obj_in=user_in_update)
     assert user.email  # Required for mypy
-    normal_user_token_headers = authentication_token_from_email(
+    normal_user_token_headers = await authentication_token_from_email(
         client=client, email=user.email, db_session=db_session
     )
     params = {"image": True}
 
-    response = client.get(
+    response = await client.get(
         f"{settings.API_V1_STR}/users/question",
         headers=normal_user_token_headers,
         params=params,
@@ -356,17 +376,19 @@ def test_get_question_image(client: TestClient, db_session: Session) -> None:
     assert response.headers[content_type_header] == png_content_type()
 
 
-def test_get_question_redirect_if_none(client: TestClient, db_session: Session) -> None:
+async def test_get_question_redirect_if_none(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
     question_number = random_int()
-    user = create_random_user(db_session)
+    user = await create_random_user(db_session)
     user_in_update = UserUpdate(question_number=question_number)
-    user = crud.user.update(db_session, db_obj=user, obj_in=user_in_update)
+    user = await crud.user.update(db_session, db_obj=user, obj_in=user_in_update)
     assert user.email  # Required for mypy
-    normal_user_token_headers = authentication_token_from_email(
+    normal_user_token_headers = await authentication_token_from_email(
         client=client, email=user.email, db_session=db_session
     )
 
-    response = client.get(
+    response = await client.get(
         f"{settings.API_V1_STR}/users/question",
         headers=normal_user_token_headers,
         allow_redirects=False,
@@ -375,19 +397,19 @@ def test_get_question_redirect_if_none(client: TestClient, db_session: Session) 
     assert response.status_code == 307
 
 
-def test_get_question_redirect_if_none_allow_redirects(
-    client: TestClient, db_session: Session
+async def test_get_question_redirect_if_none_allow_redirects(
+    client: AsyncClient, db_session: AsyncSession
 ) -> None:
     question_number = random_int()
-    user = create_random_user(db_session)
+    user = await create_random_user(db_session)
     user_in_update = UserUpdate(question_number=question_number)
-    user = crud.user.update(db_session, db_obj=user, obj_in=user_in_update)
+    user = await crud.user.update(db_session, db_obj=user, obj_in=user_in_update)
     assert user.email  # Required for mypy
-    normal_user_token_headers = authentication_token_from_email(
+    normal_user_token_headers = await authentication_token_from_email(
         client=client, email=user.email, db_session=db_session
     )
 
-    response = client.get(
+    response = await client.get(
         f"{settings.API_V1_STR}/users/question",
         headers=normal_user_token_headers,
         allow_redirects=True,
@@ -400,20 +422,22 @@ def test_get_question_redirect_if_none_allow_redirects(
     assert "message" in message_json
 
 
-def test_verify_answer_correct_answer(client: TestClient, db_session: Session) -> None:
-    question_order_item = create_random_question_order_item(db_session)
+async def test_verify_answer_correct_answer(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    question_order_item = await create_random_question_order_item(db_session)
     question_number = question_order_item.question_number
-    user = create_random_user(db_session)
+    user = await create_random_user(db_session)
     user_in_update = UserUpdate(question_number=question_number)
-    user = crud.user.update(db_session, db_obj=user, obj_in=user_in_update)
+    user = await crud.user.update(db_session, db_obj=user, obj_in=user_in_update)
     assert user.email
-    normal_user_token_headers = authentication_token_from_email(
+    normal_user_token_headers = await authentication_token_from_email(
         client=client, email=user.email, db_session=db_session
     )
     answer = question_order_item.question.answer
     data = {"answer": answer}
 
-    response = client.post(
+    response = await client.post(
         f"{settings.API_V1_STR}/users/answer",
         headers=normal_user_token_headers,
         json=data,
@@ -424,8 +448,8 @@ def test_verify_answer_correct_answer(client: TestClient, db_session: Session) -
     assert user.id
     assert user.rank
     old_rank = user.rank
-    updated_user = crud.user.get(db_session, identifier=user.id)
-    db_session.refresh(updated_user)
+    updated_user = await crud.user.get(db_session, identifier=user.id)
+    await db_session.refresh(updated_user)
 
     assert updated_user
     assert updated_user.question_number
@@ -435,22 +459,22 @@ def test_verify_answer_correct_answer(client: TestClient, db_session: Session) -
     assert updated_user.rank >= old_rank
 
 
-def test_verify_answer_incorrect_answer(
-    client: TestClient, db_session: Session
+async def test_verify_answer_incorrect_answer(
+    client: AsyncClient, db_session: AsyncSession
 ) -> None:
-    question_order_item = create_random_question_order_item(db_session)
+    question_order_item = await create_random_question_order_item(db_session)
     question_number = question_order_item.question_number
-    user = create_random_user(db_session)
+    user = await create_random_user(db_session)
     user_in_update = UserUpdate(question_number=question_number)
-    user = crud.user.update(db_session, db_obj=user, obj_in=user_in_update)
+    user = await crud.user.update(db_session, db_obj=user, obj_in=user_in_update)
     assert user.email
-    normal_user_token_headers = authentication_token_from_email(
+    normal_user_token_headers = await authentication_token_from_email(
         client=client, email=user.email, db_session=db_session
     )
     answer = random_lower_string()
     data = {"answer": answer}
 
-    response = client.post(
+    response = await client.post(
         f"{settings.API_V1_STR}/users/answer",
         headers=normal_user_token_headers,
         json=data,
@@ -461,7 +485,7 @@ def test_verify_answer_incorrect_answer(
     assert user.id
     assert user.rank
     old_rank = user.rank
-    unmodified_user = crud.user.get(db_session, identifier=user.id)
+    unmodified_user = await crud.user.get(db_session, identifier=user.id)
 
     assert unmodified_user
     assert unmodified_user.question_number
@@ -471,12 +495,14 @@ def test_verify_answer_incorrect_answer(
     assert unmodified_user.rank == old_rank
 
 
-def test_retrieve_leaderboard(client: TestClient, db_session: Session) -> None:
-    create_random_user(db_session)
-    create_random_user(db_session)
-    create_random_user(db_session)
+async def test_retrieve_leaderboard(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    await create_random_user(db_session)
+    await create_random_user(db_session)
+    await create_random_user(db_session)
 
-    response = client.get(f"{settings.API_V1_STR}/users/leaderboard")
+    response = await client.get(f"{settings.API_V1_STR}/users/leaderboard")
     all_users = response.json()
 
     assert len(all_users) > 1

--- a/app/tests/conftest.py
+++ b/app/tests/conftest.py
@@ -89,7 +89,6 @@ async def create_tables() -> AsyncGenerator[None, None]:
 @pytest.fixture(scope="session")
 async def db_session() -> AsyncGenerator[AsyncSession, None]:
     try:
-
         db_session = TestingSessionLocal()
         yield db_session
 

--- a/app/tests/conftest.py
+++ b/app/tests/conftest.py
@@ -2,13 +2,14 @@
 # pylint: disable=missing-module-docstring
 # pylint: disable=redefined-outer-name
 
+import asyncio
 import logging
-from typing import Dict, Generator
+from typing import AsyncGenerator, Dict, Generator
 
 import pytest
 from fastapi.testclient import TestClient
-from sqlalchemy import create_engine
-from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
 
 from app.api.dependencies import get_db_session
 from app.core.config import settings
@@ -25,25 +26,43 @@ LOGGER = logging.getLogger(__name__)
 # Use separate database for testing
 assert settings.SQLALCHEMY_TEST_DATABASE_URI
 
-engine = create_engine(
+engine = create_async_engine(
     settings.SQLALCHEMY_TEST_DATABASE_URI, pool_pre_ping=True, future=True
 )
-TestingSessionLocal = sessionmaker(autoflush=False, bind=engine, future=True)
+TestingSessionLocal = sessionmaker(
+    autoflush=False,
+    bind=engine,
+    expire_on_commit=False,
+    class_=AsyncSession,
+    future=True,
+)
 
 
-def override_get_db_session() -> Generator:
+async def override_get_db_session() -> AsyncGenerator:
     try:
         db_session = TestingSessionLocal()
         yield db_session
 
     finally:
-        db_session.close()
+        await db_session.close()
+
+
+@pytest.fixture(scope="session")
+def event_loop() -> Generator:
+    loop = asyncio.get_event_loop_policy().new_event_loop()
+
+    yield loop
+
+    loop.close()
 
 
 @pytest.fixture(scope="session", autouse=True)
-def create_tables() -> Generator:
+async def create_tables() -> AsyncGenerator:
     LOGGER.info("Creating tables")
-    Base.metadata.create_all(bind=engine)  # pylint: disable=no-member
+
+    async with engine.begin() as connection:
+        await connection.run_sync(Base.metadata.create_all)  # pylint: disable=no-member
+
     LOGGER.info("Tables created")
 
     # Dependency overrides
@@ -52,7 +71,7 @@ def create_tables() -> Generator:
 
     LOGGER.info("Creating initial data")
     db_session = TestingSessionLocal()
-    init_db(db_session)
+    await init_db(db_session)
     LOGGER.info("Initial data created")
 
     # Run tests
@@ -60,8 +79,9 @@ def create_tables() -> Generator:
 
     LOGGER.info("Clearing data in tables")
     for table in reversed(Base.metadata.sorted_tables):  # pylint: disable=no-member
-        db_session.execute(table.delete())
-    db_session.commit()
+        await db_session.execute(table.delete())
+
+    await db_session.commit()
     LOGGER.info("Tables cleared")
 
 
@@ -82,9 +102,9 @@ def superuser_token_headers(client: TestClient) -> Dict[str, str]:
 
 
 @pytest.fixture(scope="module")
-def normal_user_token_headers(
-    client: TestClient, db_session: Session
+async def normal_user_token_headers(
+    client: TestClient, db_session: AsyncSession
 ) -> Dict[str, str]:
-    return authentication_token_from_email(
+    return await authentication_token_from_email(
         client=client, email=settings.EMAIL_TEST_USER, db_session=db_session
     )

--- a/app/tests/crud/test_question.py
+++ b/app/tests/crud/test_question.py
@@ -1,15 +1,18 @@
 # pylint: disable=missing-function-docstring
 # pylint: disable=missing-module-docstring
 
-from sqlalchemy.orm import Session
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from app import crud
 from app.schemas.question import QuestionCreate, QuestionUpdate
 from app.tests.utils.question import horse_image_contents, png_content_type
 from app.tests.utils.utils import random_lower_string
 
+pytestmark = pytest.mark.asyncio
 
-def test_create_question(db_session: Session) -> None:
+
+async def test_create_question(db_session: AsyncSession) -> None:
     answer = random_lower_string()
     content = horse_image_contents()
     question_in = QuestionCreate(
@@ -17,24 +20,24 @@ def test_create_question(db_session: Session) -> None:
         content=content,
         content_type=png_content_type(),
     )
-    question = crud.question.create(db_session, obj_in=question_in)
+    question = await crud.question.create(db_session, obj_in=question_in)
 
     assert question.answer == answer
     assert question.content_type == png_content_type()
     assert question.content == content
 
 
-def test_get_question(db_session: Session) -> None:
+async def test_get_question(db_session: AsyncSession) -> None:
     answer = random_lower_string()
     question_in = QuestionCreate(
         answer=answer,
         content=horse_image_contents(),
         content_type=png_content_type(),
     )
-    question = crud.question.create(db_session, obj_in=question_in)
+    question = await crud.question.create(db_session, obj_in=question_in)
 
     assert question.id  # Required for mypy
-    question_2 = crud.question.get(db_session, identifier=question.id)
+    question_2 = await crud.question.get(db_session, identifier=question.id)
 
     assert question_2
     assert question.content == question_2.content
@@ -43,18 +46,18 @@ def test_get_question(db_session: Session) -> None:
     assert question.dict() == question_2.dict()
 
 
-def test_update_question(db_session: Session) -> None:
+async def test_update_question(db_session: AsyncSession) -> None:
     answer = random_lower_string()
     question_in = QuestionCreate(
         answer=answer,
         content=horse_image_contents(),
         content_type=png_content_type(),
     )
-    question = crud.question.create(db_session, obj_in=question_in)
+    question = await crud.question.create(db_session, obj_in=question_in)
 
     new_answer = random_lower_string()
     question_in_update = QuestionUpdate(answer=new_answer)
-    crud.question.update(
+    await crud.question.update(
         db_session,
         db_obj=question,
         obj_in=question_in_update,
@@ -62,7 +65,7 @@ def test_update_question(db_session: Session) -> None:
     )
 
     assert question.id
-    updated_question = crud.question.get(db_session, identifier=question.id)
+    updated_question = await crud.question.get(db_session, identifier=question.id)
 
     assert updated_question
     assert updated_question.content == question.content
@@ -70,17 +73,17 @@ def test_update_question(db_session: Session) -> None:
     assert updated_question.answer == new_answer
 
 
-def test_delete_question(db_session: Session) -> None:
+async def test_delete_question(db_session: AsyncSession) -> None:
     answer = random_lower_string()
     question_in = QuestionCreate(
         answer=answer,
         content=horse_image_contents(),
         content_type=png_content_type(),
     )
-    question = crud.question.create(db_session, obj_in=question_in)
+    question = await crud.question.create(db_session, obj_in=question_in)
 
     assert question.id
-    deleted_question = crud.question.remove(db_session, identifier=question.id)
+    deleted_question = await crud.question.remove(db_session, identifier=question.id)
 
     assert deleted_question.id == question.id
     assert deleted_question.answer == question.answer
@@ -88,6 +91,6 @@ def test_delete_question(db_session: Session) -> None:
     assert deleted_question.content == question.content
     assert deleted_question.dict() == question.dict()
 
-    result = crud.question.get(db_session, identifier=question.id)
+    result = await crud.question.get(db_session, identifier=question.id)
 
     assert result is None

--- a/app/tests/crud/test_question_order_item.py
+++ b/app/tests/crud/test_question_order_item.py
@@ -1,7 +1,8 @@
 # pylint: disable=missing-function-docstring
 # pylint: disable=missing-module-docstring
 
-from sqlalchemy.orm import Session
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from app import crud
 from app.schemas.question_order_item import (
@@ -11,15 +12,17 @@ from app.schemas.question_order_item import (
 from app.tests.utils.question import create_random_question
 from app.tests.utils.utils import random_int
 
+pytestmark = pytest.mark.asyncio
 
-def test_create_question_order_item(db_session: Session) -> None:
-    question = create_random_question(db_session)
+
+async def test_create_question_order_item(db_session: AsyncSession) -> None:
+    question = await create_random_question(db_session)
     question_id = question.id
     question_number = random_int()
     question_order_item_in = QuestionOrderItemCreate(
         question_id=question_id, question_number=question_number
     )
-    question_order_item = crud.question_order_item.create(
+    question_order_item = await crud.question_order_item.create(
         db_session, obj_in=question_order_item_in
     )
 
@@ -28,19 +31,19 @@ def test_create_question_order_item(db_session: Session) -> None:
     assert question_order_item.question.dict() == question.dict()
 
 
-def test_get_question_order_item(db_session: Session) -> None:
-    question = create_random_question(db_session)
+async def test_get_question_order_item(db_session: AsyncSession) -> None:
+    question = await create_random_question(db_session)
     question_id = question.id
     question_number = random_int()
     question_order_item_in = QuestionOrderItemCreate(
         question_id=question_id, question_number=question_number
     )
-    question_order_item = crud.question_order_item.create(
+    question_order_item = await crud.question_order_item.create(
         db_session, obj_in=question_order_item_in
     )
 
     assert question_order_item.id  # Required for mypy
-    question_order_item_2 = crud.question_order_item.get(
+    question_order_item_2 = await crud.question_order_item.get(
         db_session, identifier=question_order_item.id
     )
 
@@ -51,21 +54,21 @@ def test_get_question_order_item(db_session: Session) -> None:
     assert question_order_item.dict() == question_order_item_2.dict()
 
 
-def test_update_question_order_item_question_id(db_session: Session) -> None:
-    question = create_random_question(db_session)
+async def test_update_question_order_item_question_id(db_session: AsyncSession) -> None:
+    question = await create_random_question(db_session)
     question_id = question.id
     question_number = random_int()
     question_order_item_in = QuestionOrderItemCreate(
         question_id=question_id, question_number=question_number
     )
-    question_order_item = crud.question_order_item.create(
+    question_order_item = await crud.question_order_item.create(
         db_session, obj_in=question_order_item_in
     )
 
-    new_question = create_random_question(db_session)
+    new_question = await create_random_question(db_session)
     new_question_id = new_question.id
     question_order_item_in_update = QuestionOrderItemUpdate(question_id=new_question_id)
-    crud.question_order_item.update(
+    await crud.question_order_item.update(
         db_session,
         db_obj=question_order_item,
         obj_in=question_order_item_in_update,
@@ -73,7 +76,7 @@ def test_update_question_order_item_question_id(db_session: Session) -> None:
     )
 
     assert question_order_item.id
-    updated_question_order_item = crud.question_order_item.get(
+    updated_question_order_item = await crud.question_order_item.get(
         db_session, identifier=question_order_item.id
     )
 
@@ -86,14 +89,16 @@ def test_update_question_order_item_question_id(db_session: Session) -> None:
     )
 
 
-def test_update_question_order_item_question_number(db_session: Session) -> None:
-    question = create_random_question(db_session)
+async def test_update_question_order_item_question_number(
+    db_session: AsyncSession,
+) -> None:
+    question = await create_random_question(db_session)
     question_id = question.id
     question_number = random_int()
     question_order_item_in = QuestionOrderItemCreate(
         question_id=question_id, question_number=question_number
     )
-    question_order_item = crud.question_order_item.create(
+    question_order_item = await crud.question_order_item.create(
         db_session, obj_in=question_order_item_in
     )
 
@@ -101,7 +106,7 @@ def test_update_question_order_item_question_number(db_session: Session) -> None
     question_order_item_in_update = QuestionOrderItemUpdate(
         question_number=new_question_number
     )
-    crud.question_order_item.update(
+    await crud.question_order_item.update(
         db_session,
         db_obj=question_order_item,
         obj_in=question_order_item_in_update,
@@ -109,7 +114,7 @@ def test_update_question_order_item_question_number(db_session: Session) -> None
     )
 
     assert question_order_item.id
-    updated_question_order_item = crud.question_order_item.get(
+    updated_question_order_item = await crud.question_order_item.get(
         db_session, identifier=question_order_item.id
     )
 
@@ -122,19 +127,19 @@ def test_update_question_order_item_question_number(db_session: Session) -> None
     assert updated_question_order_item.question_number == new_question_number
 
 
-def test_delete_question_order_item(db_session: Session) -> None:
-    question = create_random_question(db_session)
+async def test_delete_question_order_item(db_session: AsyncSession) -> None:
+    question = await create_random_question(db_session)
     question_id = question.id
     question_number = random_int()
     question_order_item_in = QuestionOrderItemCreate(
         question_id=question_id, question_number=question_number
     )
-    question_order_item = crud.question_order_item.create(
+    question_order_item = await crud.question_order_item.create(
         db_session, obj_in=question_order_item_in
     )
 
     assert question_order_item.id
-    deleted_question_order_item = crud.question_order_item.remove(
+    deleted_question_order_item = await crud.question_order_item.remove(
         db_session, identifier=question_order_item.id
     )
 
@@ -146,6 +151,8 @@ def test_delete_question_order_item(db_session: Session) -> None:
     )
     assert deleted_question_order_item.dict() == question_order_item.dict()
 
-    result = crud.question_order_item.get(db_session, identifier=question_order_item.id)
+    result = await crud.question_order_item.get(
+        db_session, identifier=question_order_item.id
+    )
 
     assert result is None

--- a/app/tests/utils/question.py
+++ b/app/tests/utils/question.py
@@ -1,7 +1,7 @@
 # pylint: disable=missing-function-docstring
 # pylint: disable=missing-module-docstring
 
-from sqlalchemy.orm import Session
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from app import crud
 from app.models.question import Question
@@ -28,7 +28,7 @@ def horse_image_contents() -> bytes:
     return contents
 
 
-def create_random_question(db_session: Session) -> Question:
+async def create_random_question(db_session: AsyncSession) -> Question:
     answer = random_lower_string()
     content = horse_image_contents()
     question_in = QuestionCreate(
@@ -36,6 +36,6 @@ def create_random_question(db_session: Session) -> Question:
         content=content,
         content_type=png_content_type(),
     )
-    question = crud.question.create(db_session, obj_in=question_in)
+    question = await crud.question.create(db_session, obj_in=question_in)
 
     return question

--- a/app/tests/utils/question_order_item.py
+++ b/app/tests/utils/question_order_item.py
@@ -1,7 +1,7 @@
 # pylint: disable=missing-function-docstring
 # pylint: disable=missing-module-docstring
 
-from sqlalchemy.orm import Session
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from app import crud
 from app.models.question_order_item import QuestionOrderItem
@@ -10,15 +10,17 @@ from app.tests.utils.question import create_random_question
 from app.tests.utils.utils import random_int
 
 
-def create_random_question_order_item(db_session: Session) -> QuestionOrderItem:
-    question = create_random_question(db_session)
+async def create_random_question_order_item(
+    db_session: AsyncSession,
+) -> QuestionOrderItem:
+    question = await create_random_question(db_session)
     assert question.id  # Required for mypy
     question_id = question.id
     question_number = random_int()
     question_order_item_in = QuestionOrderItemCreate(
         question_id=question_id, question_number=question_number
     )
-    question_order_item = crud.question_order_item.create(
+    question_order_item = await crud.question_order_item.create(
         db_session, obj_in=question_order_item_in
     )
 

--- a/app/tests/utils/user.py
+++ b/app/tests/utils/user.py
@@ -4,7 +4,7 @@
 from typing import Dict
 
 from fastapi.testclient import TestClient
-from sqlalchemy.orm import Session
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from app import crud
 from app.core.config import settings
@@ -26,20 +26,20 @@ def user_authentication_headers(
     return headers
 
 
-def create_random_user(db_session: Session) -> User:
+async def create_random_user(db_session: AsyncSession) -> User:
     email = random_email()
     password = random_lower_string()
     full_name = random_lower_string()
     user_in = UserCreate(
         username=email, email=email, password=password, full_name=full_name
     )
-    user = crud.user.create(db_session=db_session, obj_in=user_in)
+    user = await crud.user.create(db_session=db_session, obj_in=user_in)
 
     return user
 
 
-def authentication_token_from_email(
-    *, client: TestClient, email: str, db_session: Session
+async def authentication_token_from_email(
+    *, client: TestClient, email: str, db_session: AsyncSession
 ) -> Dict[str, str]:
     """
     Return a valid token for the user with the provided email.
@@ -48,17 +48,17 @@ def authentication_token_from_email(
     """
 
     password = random_lower_string()
-    user = crud.user.get_by_email(db_session, email=email)
+    user = await crud.user.get_by_email(db_session, email=email)
 
     if not user:
         full_name = random_lower_string()
         user_in_create = UserCreate(
             username=email, email=email, password=password, full_name=full_name
         )
-        user = crud.user.create(db_session, obj_in=user_in_create)
+        user = await crud.user.create(db_session, obj_in=user_in_create)
 
     else:
         user_in_update = UserUpdate(password=password)
-        user = crud.user.update(db_session, db_obj=user, obj_in=user_in_update)
+        user = await crud.user.update(db_session, db_obj=user, obj_in=user_in_update)
 
     return user_authentication_headers(client=client, email=email, password=password)

--- a/app/tests/utils/utils.py
+++ b/app/tests/utils/utils.py
@@ -5,7 +5,7 @@ import random
 import string
 from typing import Dict
 
-from fastapi.testclient import TestClient
+from httpx import AsyncClient
 
 from app.core.config import settings
 
@@ -22,13 +22,15 @@ def random_email() -> str:
     return f"{random_lower_string()}@{random_lower_string()}.com"
 
 
-def get_superuser_token_headers(client: TestClient) -> Dict[str, str]:
+async def get_superuser_token_headers(client: AsyncClient) -> Dict[str, str]:
     login_data = {
         "username": settings.FIRST_SUPERUSER,
         "password": settings.FIRST_SUPERUSER_PASSWORD,
     }
 
-    response = client.post(f"{settings.API_V1_STR}/login/access-token", data=login_data)
+    response = await client.post(
+        f"{settings.API_V1_STR}/login/access-token", data=login_data
+    )
     tokens = response.json()
     a_token = tokens["access_token"]
     headers = {"Authorization": f"Bearer {a_token}"}

--- a/app/tests_pre_start.py
+++ b/app/tests_pre_start.py
@@ -2,6 +2,7 @@
 Pre-start script run before tests, to verify database connectivity.
 """
 
+import asyncio
 import logging
 
 from sqlalchemy import text
@@ -24,7 +25,7 @@ LOGGER = logging.getLogger("tests_pre_start")
     before=before_log(LOGGER, logging.INFO),
     after=after_log(LOGGER, logging.WARN),
 )
-def verify_db_connectivity() -> None:
+async def verify_db_connectivity() -> None:
     """
     Verify database connectivity.
     """
@@ -32,8 +33,9 @@ def verify_db_connectivity() -> None:
     try:
         # Try to create a session and execute a statement to check if database is
         # available
-        db_session = TestingSessionLocal()
-        db_session.execute(text("SELECT 1;"))
+        async with TestingSessionLocal() as db_session:
+            await db_session.execute(text("SELECT 1;"))
+
         LOGGER.info("Database connection successful")
 
     except Exception as exception:
@@ -41,15 +43,15 @@ def verify_db_connectivity() -> None:
         raise
 
 
-def main() -> None:
+async def main() -> None:
     """
     Driver function.
     """
 
     LOGGER.info("Initializing service")
-    verify_db_connectivity()
+    await verify_db_connectivity()
     LOGGER.info("Service finished initializing")
 
 
 if __name__ == "__main__":
-    main()
+    asyncio.run(main())

--- a/app/utils.py
+++ b/app/utils.py
@@ -86,7 +86,7 @@ async def send_test_email(email_to: str) -> None:
         template_str = file.read()
 
     await LOGGER.info("Sending test email", email=email_to)
-    send_email(
+    await send_email(
         email_to=email_to,
         subject_template=subject,
         html_template=template_str,
@@ -115,7 +115,7 @@ async def send_reset_password_email(email_to: str, email: str, token: str) -> No
     server_host = settings.SERVER_HOST
     link = f"{server_host}/reset-password?token={token}"
     await LOGGER.info("Sending password recovery email", email=email_to)
-    send_email(
+    await send_email(
         email_to=email_to,
         subject_template=subject,
         html_template=template_str,
@@ -151,7 +151,7 @@ async def send_new_account_email(email_to: str, username: str, password: str) ->
 
     link = settings.SERVER_HOST
     await LOGGER.info("Sending account creation email", email=email_to)
-    send_email(
+    await send_email(
         email_to=email_to,
         subject_template=subject,
         html_template=template_str,

--- a/poetry.lock
+++ b/poetry.lock
@@ -1068,7 +1068,7 @@ python-versions = "*"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.9"
-content-hash = "c5013c31168f39dbb8e7b1d272370ffd48da84e889eaab41ec21188a9c5c2f6d"
+content-hash = "8573e420bd46eab40a9ee63dffa73f4c4891934a96445dc44c0033ca3f3a3ef4"
 
 [metadata.files]
 alembic = [
@@ -1102,10 +1102,6 @@ argon2-cffi = [
     {file = "argon2_cffi-20.1.0-cp38-cp38-win_amd64.whl", hash = "sha256:9dfd5197852530294ecb5795c97a823839258dfd5eb9420233c7cfedec2058f2"},
     {file = "argon2_cffi-20.1.0-cp39-cp39-win32.whl", hash = "sha256:e2db6e85c057c16d0bd3b4d2b04f270a7467c147381e8fd73cbbe5bc719832be"},
     {file = "argon2_cffi-20.1.0-cp39-cp39-win_amd64.whl", hash = "sha256:8a84934bd818e14a17943de8099d41160da4a336bcc699bb4c394bbb9b94bd32"},
-    {file = "argon2_cffi-20.1.0-pp36-pypy36_pp73-macosx_10_7_x86_64.whl", hash = "sha256:b94042e5dcaa5d08cf104a54bfae614be502c6f44c9c89ad1535b2ebdaacbd4c"},
-    {file = "argon2_cffi-20.1.0-pp36-pypy36_pp73-win32.whl", hash = "sha256:8282b84ceb46b5b75c3a882b28856b8cd7e647ac71995e71b6705ec06fc232c3"},
-    {file = "argon2_cffi-20.1.0-pp37-pypy37_pp73-macosx_10_7_x86_64.whl", hash = "sha256:3aa804c0e52f208973845e8b10c70d8957c9e5a666f702793256242e9167c4e0"},
-    {file = "argon2_cffi-20.1.0-pp37-pypy37_pp73-win_amd64.whl", hash = "sha256:36320372133a003374ef4275fbfce78b7ab581440dfca9f9471be3dd9a522428"},
 ]
 asgi-lifespan = [
     {file = "asgi-lifespan-1.0.1.tar.gz", hash = "sha256:9a33e7da2073c4764bc79bd6136501d6c42f60e3d2168ba71235e84122eadb7f"},
@@ -1281,10 +1277,8 @@ cryptography = [
     {file = "cryptography-3.4.7-cp36-abi3-win_amd64.whl", hash = "sha256:de4e5f7f68220d92b7637fc99847475b59154b7a1b3868fb7385337af54ac9ca"},
     {file = "cryptography-3.4.7-pp36-pypy36_pp73-manylinux2010_x86_64.whl", hash = "sha256:26965837447f9c82f1855e0bc8bc4fb910240b6e0d16a664bb722df3b5b06873"},
     {file = "cryptography-3.4.7-pp36-pypy36_pp73-manylinux2014_x86_64.whl", hash = "sha256:eb8cc2afe8b05acbd84a43905832ec78e7b3873fb124ca190f574dca7389a87d"},
-    {file = "cryptography-3.4.7-pp37-pypy37_pp73-macosx_10_10_x86_64.whl", hash = "sha256:b01fd6f2737816cb1e08ed4807ae194404790eac7ad030b34f2ce72b332f5586"},
     {file = "cryptography-3.4.7-pp37-pypy37_pp73-manylinux2010_x86_64.whl", hash = "sha256:7ec5d3b029f5fa2b179325908b9cd93db28ab7b85bb6c1db56b10e0b54235177"},
     {file = "cryptography-3.4.7-pp37-pypy37_pp73-manylinux2014_x86_64.whl", hash = "sha256:ee77aa129f481be46f8d92a1a7db57269a2f23052d5f2433b4621bb457081cc9"},
-    {file = "cryptography-3.4.7-pp37-pypy37_pp73-win_amd64.whl", hash = "sha256:bf40af59ca2465b24e54f671b2de2c59257ddc4f7e5706dbd6930e26823668d3"},
     {file = "cryptography-3.4.7.tar.gz", hash = "sha256:3d10de8116d25649631977cb37da6cbdd2d6fa0e0281d014a5b7d337255ca713"},
 ]
 cssselect = [
@@ -1451,8 +1445,6 @@ lxml = [
     {file = "lxml-4.6.3-cp27-cp27m-win_amd64.whl", hash = "sha256:8157dadbb09a34a6bd95a50690595e1fa0af1a99445e2744110e3dca7831c4ee"},
     {file = "lxml-4.6.3-cp27-cp27mu-manylinux1_i686.whl", hash = "sha256:7728e05c35412ba36d3e9795ae8995e3c86958179c9770e65558ec3fdfd3724f"},
     {file = "lxml-4.6.3-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:4bff24dfeea62f2e56f5bab929b4428ae6caba2d1eea0c2d6eb618e30a71e6d4"},
-    {file = "lxml-4.6.3-cp310-cp310-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_24_i686.whl", hash = "sha256:64812391546a18896adaa86c77c59a4998f33c24788cadc35789e55b727a37f4"},
-    {file = "lxml-4.6.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:c1a40c06fd5ba37ad39caa0b3144eb3772e813b5fb5b084198a985431c2f1e8d"},
     {file = "lxml-4.6.3-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:74f7d8d439b18fa4c385f3f5dfd11144bb87c1da034a466c5b5577d23a1d9b51"},
     {file = "lxml-4.6.3-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:f90ba11136bfdd25cae3951af8da2e95121c9b9b93727b1b896e3fa105b2f586"},
     {file = "lxml-4.6.3-cp35-cp35m-manylinux2010_i686.whl", hash = "sha256:4c61b3a0db43a1607d6264166b230438f85bfed02e8cff20c22e564d0faff354"},
@@ -1498,22 +1490,12 @@ mako = [
     {file = "Mako-1.1.4.tar.gz", hash = "sha256:17831f0b7087c313c0ffae2bcbbd3c1d5ba9eeac9c38f2eb7b50e8c99fe9d5ab"},
 ]
 markupsafe = [
-    {file = "MarkupSafe-2.0.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:d8446c54dc28c01e5a2dbac5a25f071f6653e6e40f3a8818e8b45d790fe6ef53"},
-    {file = "MarkupSafe-2.0.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:36bc903cbb393720fad60fc28c10de6acf10dc6cc883f3e24ee4012371399a38"},
-    {file = "MarkupSafe-2.0.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2d7d807855b419fc2ed3e631034685db6079889a1f01d5d9dac950f764da3dad"},
-    {file = "MarkupSafe-2.0.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:add36cb2dbb8b736611303cd3bfcee00afd96471b09cda130da3581cbdc56a6d"},
-    {file = "MarkupSafe-2.0.1-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:168cd0a3642de83558a5153c8bd34f175a9a6e7f6dc6384b9655d2697312a646"},
-    {file = "MarkupSafe-2.0.1-cp310-cp310-win32.whl", hash = "sha256:99df47edb6bda1249d3e80fdabb1dab8c08ef3975f69aed437cb69d0a5de1e28"},
-    {file = "MarkupSafe-2.0.1-cp310-cp310-win_amd64.whl", hash = "sha256:e0f138900af21926a02425cf736db95be9f4af72ba1bb21453432a07f6082134"},
     {file = "MarkupSafe-2.0.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:f9081981fe268bd86831e5c75f7de206ef275defcb82bc70740ae6dc507aee51"},
     {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:0955295dd5eec6cb6cc2fe1698f4c6d84af2e92de33fbcac4111913cd100a6ff"},
     {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:0446679737af14f45767963a1a9ef7620189912317d095f2d9ffa183a4d25d2b"},
     {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux2010_i686.whl", hash = "sha256:f826e31d18b516f653fe296d967d700fddad5901ae07c622bb3705955e1faa94"},
     {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:fa130dd50c57d53368c9d59395cb5526eda596d3ffe36666cd81a44d56e48872"},
     {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:905fec760bd2fa1388bb5b489ee8ee5f7291d692638ea5f67982d968366bef9f"},
-    {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bf5d821ffabf0ef3533c39c518f3357b171a1651c1ff6827325e4489b0e46c3c"},
-    {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:0d4b31cc67ab36e3392bbf3862cfbadac3db12bdd8b02a2731f509ed5b829724"},
-    {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:baa1a4e8f868845af802979fcdbf0bb11f94f1cb7ced4c4b8a351bb60d108145"},
     {file = "MarkupSafe-2.0.1-cp36-cp36m-win32.whl", hash = "sha256:6c4ca60fa24e85fe25b912b01e62cb969d69a23a5d5867682dd3e80b5b02581d"},
     {file = "MarkupSafe-2.0.1-cp36-cp36m-win_amd64.whl", hash = "sha256:b2f4bf27480f5e5e8ce285a8c8fd176c0b03e93dcc6646477d4630e83440c6a9"},
     {file = "MarkupSafe-2.0.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:0717a7390a68be14b8c793ba258e075c6f4ca819f15edfc2a3a027c823718567"},
@@ -1522,21 +1504,14 @@ markupsafe = [
     {file = "MarkupSafe-2.0.1-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:d7f9850398e85aba693bb640262d3611788b1f29a79f0c93c565694658f4071f"},
     {file = "MarkupSafe-2.0.1-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:6a7fae0dd14cf60ad5ff42baa2e95727c3d81ded453457771d02b7d2b3f9c0c2"},
     {file = "MarkupSafe-2.0.1-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:b7f2d075102dc8c794cbde1947378051c4e5180d52d276987b8d28a3bd58c17d"},
-    {file = "MarkupSafe-2.0.1-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e9936f0b261d4df76ad22f8fee3ae83b60d7c3e871292cd42f40b81b70afae85"},
-    {file = "MarkupSafe-2.0.1-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:2a7d351cbd8cfeb19ca00de495e224dea7e7d919659c2841bbb7f420ad03e2d6"},
-    {file = "MarkupSafe-2.0.1-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:60bf42e36abfaf9aff1f50f52644b336d4f0a3fd6d8a60ca0d054ac9f713a864"},
     {file = "MarkupSafe-2.0.1-cp37-cp37m-win32.whl", hash = "sha256:a30e67a65b53ea0a5e62fe23682cfe22712e01f453b95233b25502f7c61cb415"},
     {file = "MarkupSafe-2.0.1-cp37-cp37m-win_amd64.whl", hash = "sha256:611d1ad9a4288cf3e3c16014564df047fe08410e628f89805e475368bd304914"},
-    {file = "MarkupSafe-2.0.1-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:5bb28c636d87e840583ee3adeb78172efc47c8b26127267f54a9c0ec251d41a9"},
     {file = "MarkupSafe-2.0.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:be98f628055368795d818ebf93da628541e10b75b41c559fdf36d104c5787066"},
     {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux1_i686.whl", hash = "sha256:1d609f577dc6e1aa17d746f8bd3c31aa4d258f4070d61b2aa5c4166c1539de35"},
     {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:7d91275b0245b1da4d4cfa07e0faedd5b0812efc15b702576d103293e252af1b"},
     {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:01a9b8ea66f1658938f65b93a85ebe8bc016e6769611be228d797c9d998dd298"},
     {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:47ab1e7b91c098ab893b828deafa1203de86d0bc6ab587b160f78fe6c4011f75"},
     {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:97383d78eb34da7e1fa37dd273c20ad4320929af65d156e35a5e2d89566d9dfb"},
-    {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6fcf051089389abe060c9cd7caa212c707e58153afa2c649f00346ce6d260f1b"},
-    {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:5855f8438a7d1d458206a2466bf82b0f104a3724bf96a1c781ab731e4201731a"},
-    {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:3dd007d54ee88b46be476e293f48c85048603f5f516008bee124ddd891398ed6"},
     {file = "MarkupSafe-2.0.1-cp38-cp38-win32.whl", hash = "sha256:023cb26ec21ece8dc3907c0e8320058b2e0cb3c55cf9564da612bc325bed5e64"},
     {file = "MarkupSafe-2.0.1-cp38-cp38-win_amd64.whl", hash = "sha256:984d76483eb32f1bcb536dc27e4ad56bba4baa70be32fa87152832cdd9db0833"},
     {file = "MarkupSafe-2.0.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:2ef54abee730b502252bcdf31b10dacb0a416229b72c18b19e24a4509f273d26"},
@@ -1546,9 +1521,6 @@ markupsafe = [
     {file = "MarkupSafe-2.0.1-cp39-cp39-manylinux2010_i686.whl", hash = "sha256:4efca8f86c54b22348a5467704e3fec767b2db12fc39c6d963168ab1d3fc9135"},
     {file = "MarkupSafe-2.0.1-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:ab3ef638ace319fa26553db0624c4699e31a28bb2a835c5faca8f8acf6a5a902"},
     {file = "MarkupSafe-2.0.1-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:f8ba0e8349a38d3001fae7eadded3f6606f0da5d748ee53cc1dab1d6527b9509"},
-    {file = "MarkupSafe-2.0.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c47adbc92fc1bb2b3274c4b3a43ae0e4573d9fbff4f54cd484555edbf030baf1"},
-    {file = "MarkupSafe-2.0.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:37205cac2a79194e3750b0af2a5720d95f786a55ce7df90c3af697bfa100eaac"},
-    {file = "MarkupSafe-2.0.1-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:1f2ade76b9903f39aa442b4aadd2177decb66525062db244b35d71d0ee8599b6"},
     {file = "MarkupSafe-2.0.1-cp39-cp39-win32.whl", hash = "sha256:10f82115e21dc0dfec9ab5c0223652f7197feb168c940f3ef61563fc2d6beb74"},
     {file = "MarkupSafe-2.0.1-cp39-cp39-win_amd64.whl", hash = "sha256:693ce3f9e70a6cf7d2fb9e6c9d8b204b6b39897a2c4a1aa65728d5ac97dcc1d8"},
     {file = "MarkupSafe-2.0.1.tar.gz", hash = "sha256:594c67807fb16238b30c44bdf74f36c02cdf22d1c8cda91ef8a0ed8dabf5620a"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -645,6 +645,20 @@ toml = "*"
 testing = ["argcomplete", "hypothesis (>=3.56)", "mock", "nose", "requests", "xmlschema"]
 
 [[package]]
+name = "pytest-asyncio"
+version = "0.15.1"
+description = "Pytest support for asyncio."
+category = "dev"
+optional = false
+python-versions = ">= 3.6"
+
+[package.dependencies]
+pytest = ">=5.4.0"
+
+[package.extras]
+testing = ["coverage", "hypothesis (>=5.7.1)"]
+
+[[package]]
 name = "pytest-cov"
 version = "2.12.1"
 description = "Pytest plugin for measuring coverage."
@@ -970,7 +984,7 @@ python-versions = "*"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.9"
-content-hash = "99bd7496e8d17d3d5a91c00a88de759c020eb888b7079dadb55149f24895a54d"
+content-hash = "cb3587a6569672347cec982cf1a320441073e045e187f3d9e7e7c5f7cfd44dd7"
 
 [metadata.files]
 alembic = [
@@ -1533,6 +1547,10 @@ pyparsing = [
 pytest = [
     {file = "pytest-6.2.4-py3-none-any.whl", hash = "sha256:91ef2131a9bd6be8f76f1f08eac5c5317221d6ad1e143ae03894b862e8976890"},
     {file = "pytest-6.2.4.tar.gz", hash = "sha256:50bcad0a0b9c5a72c8e4e7c9855a3ad496ca6a881a3641b4260605450772c54b"},
+]
+pytest-asyncio = [
+    {file = "pytest-asyncio-0.15.1.tar.gz", hash = "sha256:2564ceb9612bbd560d19ca4b41347b54e7835c2f792c504f698e05395ed63f6f"},
+    {file = "pytest_asyncio-0.15.1-py3-none-any.whl", hash = "sha256:3042bcdf1c5d978f6b74d96a151c4cfb9dcece65006198389ccd7e6c60eb1eea"},
 ]
 pytest-cov = [
     {file = "pytest-cov-2.12.1.tar.gz", hash = "sha256:261ceeb8c227b726249b376b8526b600f38667ee314f910353fa318caa01f4d7"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -1007,15 +1007,15 @@ socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 
 [[package]]
 name = "uvicorn"
-version = "0.14.0"
+version = "0.15.0"
 description = "The lightning-fast ASGI server."
 category = "main"
 optional = false
 python-versions = "*"
 
 [package.dependencies]
-asgiref = ">=3.3.4"
-click = ">=7"
+asgiref = ">=3.4.0"
+click = ">=7.0"
 colorama = {version = ">=0.4", optional = true, markers = "sys_platform == \"win32\" and extra == \"standard\""}
 h11 = ">=0.8"
 httptools = {version = ">=0.2.0,<0.3.0", optional = true, markers = "extra == \"standard\""}
@@ -1068,7 +1068,7 @@ python-versions = "*"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.9"
-content-hash = "e72fbf1742693edff7098b1bad34f59de1ffcce026c1d20bf9af5633ebf84005"
+content-hash = "c5013c31168f39dbb8e7b1d272370ffd48da84e889eaab41ec21188a9c5c2f6d"
 
 [metadata.files]
 alembic = [
@@ -1102,6 +1102,10 @@ argon2-cffi = [
     {file = "argon2_cffi-20.1.0-cp38-cp38-win_amd64.whl", hash = "sha256:9dfd5197852530294ecb5795c97a823839258dfd5eb9420233c7cfedec2058f2"},
     {file = "argon2_cffi-20.1.0-cp39-cp39-win32.whl", hash = "sha256:e2db6e85c057c16d0bd3b4d2b04f270a7467c147381e8fd73cbbe5bc719832be"},
     {file = "argon2_cffi-20.1.0-cp39-cp39-win_amd64.whl", hash = "sha256:8a84934bd818e14a17943de8099d41160da4a336bcc699bb4c394bbb9b94bd32"},
+    {file = "argon2_cffi-20.1.0-pp36-pypy36_pp73-macosx_10_7_x86_64.whl", hash = "sha256:b94042e5dcaa5d08cf104a54bfae614be502c6f44c9c89ad1535b2ebdaacbd4c"},
+    {file = "argon2_cffi-20.1.0-pp36-pypy36_pp73-win32.whl", hash = "sha256:8282b84ceb46b5b75c3a882b28856b8cd7e647ac71995e71b6705ec06fc232c3"},
+    {file = "argon2_cffi-20.1.0-pp37-pypy37_pp73-macosx_10_7_x86_64.whl", hash = "sha256:3aa804c0e52f208973845e8b10c70d8957c9e5a666f702793256242e9167c4e0"},
+    {file = "argon2_cffi-20.1.0-pp37-pypy37_pp73-win_amd64.whl", hash = "sha256:36320372133a003374ef4275fbfce78b7ab581440dfca9f9471be3dd9a522428"},
 ]
 asgi-lifespan = [
     {file = "asgi-lifespan-1.0.1.tar.gz", hash = "sha256:9a33e7da2073c4764bc79bd6136501d6c42f60e3d2168ba71235e84122eadb7f"},
@@ -1277,8 +1281,10 @@ cryptography = [
     {file = "cryptography-3.4.7-cp36-abi3-win_amd64.whl", hash = "sha256:de4e5f7f68220d92b7637fc99847475b59154b7a1b3868fb7385337af54ac9ca"},
     {file = "cryptography-3.4.7-pp36-pypy36_pp73-manylinux2010_x86_64.whl", hash = "sha256:26965837447f9c82f1855e0bc8bc4fb910240b6e0d16a664bb722df3b5b06873"},
     {file = "cryptography-3.4.7-pp36-pypy36_pp73-manylinux2014_x86_64.whl", hash = "sha256:eb8cc2afe8b05acbd84a43905832ec78e7b3873fb124ca190f574dca7389a87d"},
+    {file = "cryptography-3.4.7-pp37-pypy37_pp73-macosx_10_10_x86_64.whl", hash = "sha256:b01fd6f2737816cb1e08ed4807ae194404790eac7ad030b34f2ce72b332f5586"},
     {file = "cryptography-3.4.7-pp37-pypy37_pp73-manylinux2010_x86_64.whl", hash = "sha256:7ec5d3b029f5fa2b179325908b9cd93db28ab7b85bb6c1db56b10e0b54235177"},
     {file = "cryptography-3.4.7-pp37-pypy37_pp73-manylinux2014_x86_64.whl", hash = "sha256:ee77aa129f481be46f8d92a1a7db57269a2f23052d5f2433b4621bb457081cc9"},
+    {file = "cryptography-3.4.7-pp37-pypy37_pp73-win_amd64.whl", hash = "sha256:bf40af59ca2465b24e54f671b2de2c59257ddc4f7e5706dbd6930e26823668d3"},
     {file = "cryptography-3.4.7.tar.gz", hash = "sha256:3d10de8116d25649631977cb37da6cbdd2d6fa0e0281d014a5b7d337255ca713"},
 ]
 cssselect = [
@@ -1445,6 +1451,8 @@ lxml = [
     {file = "lxml-4.6.3-cp27-cp27m-win_amd64.whl", hash = "sha256:8157dadbb09a34a6bd95a50690595e1fa0af1a99445e2744110e3dca7831c4ee"},
     {file = "lxml-4.6.3-cp27-cp27mu-manylinux1_i686.whl", hash = "sha256:7728e05c35412ba36d3e9795ae8995e3c86958179c9770e65558ec3fdfd3724f"},
     {file = "lxml-4.6.3-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:4bff24dfeea62f2e56f5bab929b4428ae6caba2d1eea0c2d6eb618e30a71e6d4"},
+    {file = "lxml-4.6.3-cp310-cp310-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_24_i686.whl", hash = "sha256:64812391546a18896adaa86c77c59a4998f33c24788cadc35789e55b727a37f4"},
+    {file = "lxml-4.6.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:c1a40c06fd5ba37ad39caa0b3144eb3772e813b5fb5b084198a985431c2f1e8d"},
     {file = "lxml-4.6.3-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:74f7d8d439b18fa4c385f3f5dfd11144bb87c1da034a466c5b5577d23a1d9b51"},
     {file = "lxml-4.6.3-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:f90ba11136bfdd25cae3951af8da2e95121c9b9b93727b1b896e3fa105b2f586"},
     {file = "lxml-4.6.3-cp35-cp35m-manylinux2010_i686.whl", hash = "sha256:4c61b3a0db43a1607d6264166b230438f85bfed02e8cff20c22e564d0faff354"},
@@ -1490,12 +1498,22 @@ mako = [
     {file = "Mako-1.1.4.tar.gz", hash = "sha256:17831f0b7087c313c0ffae2bcbbd3c1d5ba9eeac9c38f2eb7b50e8c99fe9d5ab"},
 ]
 markupsafe = [
+    {file = "MarkupSafe-2.0.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:d8446c54dc28c01e5a2dbac5a25f071f6653e6e40f3a8818e8b45d790fe6ef53"},
+    {file = "MarkupSafe-2.0.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:36bc903cbb393720fad60fc28c10de6acf10dc6cc883f3e24ee4012371399a38"},
+    {file = "MarkupSafe-2.0.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2d7d807855b419fc2ed3e631034685db6079889a1f01d5d9dac950f764da3dad"},
+    {file = "MarkupSafe-2.0.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:add36cb2dbb8b736611303cd3bfcee00afd96471b09cda130da3581cbdc56a6d"},
+    {file = "MarkupSafe-2.0.1-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:168cd0a3642de83558a5153c8bd34f175a9a6e7f6dc6384b9655d2697312a646"},
+    {file = "MarkupSafe-2.0.1-cp310-cp310-win32.whl", hash = "sha256:99df47edb6bda1249d3e80fdabb1dab8c08ef3975f69aed437cb69d0a5de1e28"},
+    {file = "MarkupSafe-2.0.1-cp310-cp310-win_amd64.whl", hash = "sha256:e0f138900af21926a02425cf736db95be9f4af72ba1bb21453432a07f6082134"},
     {file = "MarkupSafe-2.0.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:f9081981fe268bd86831e5c75f7de206ef275defcb82bc70740ae6dc507aee51"},
     {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:0955295dd5eec6cb6cc2fe1698f4c6d84af2e92de33fbcac4111913cd100a6ff"},
     {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:0446679737af14f45767963a1a9ef7620189912317d095f2d9ffa183a4d25d2b"},
     {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux2010_i686.whl", hash = "sha256:f826e31d18b516f653fe296d967d700fddad5901ae07c622bb3705955e1faa94"},
     {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:fa130dd50c57d53368c9d59395cb5526eda596d3ffe36666cd81a44d56e48872"},
     {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:905fec760bd2fa1388bb5b489ee8ee5f7291d692638ea5f67982d968366bef9f"},
+    {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bf5d821ffabf0ef3533c39c518f3357b171a1651c1ff6827325e4489b0e46c3c"},
+    {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:0d4b31cc67ab36e3392bbf3862cfbadac3db12bdd8b02a2731f509ed5b829724"},
+    {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:baa1a4e8f868845af802979fcdbf0bb11f94f1cb7ced4c4b8a351bb60d108145"},
     {file = "MarkupSafe-2.0.1-cp36-cp36m-win32.whl", hash = "sha256:6c4ca60fa24e85fe25b912b01e62cb969d69a23a5d5867682dd3e80b5b02581d"},
     {file = "MarkupSafe-2.0.1-cp36-cp36m-win_amd64.whl", hash = "sha256:b2f4bf27480f5e5e8ce285a8c8fd176c0b03e93dcc6646477d4630e83440c6a9"},
     {file = "MarkupSafe-2.0.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:0717a7390a68be14b8c793ba258e075c6f4ca819f15edfc2a3a027c823718567"},
@@ -1504,14 +1522,21 @@ markupsafe = [
     {file = "MarkupSafe-2.0.1-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:d7f9850398e85aba693bb640262d3611788b1f29a79f0c93c565694658f4071f"},
     {file = "MarkupSafe-2.0.1-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:6a7fae0dd14cf60ad5ff42baa2e95727c3d81ded453457771d02b7d2b3f9c0c2"},
     {file = "MarkupSafe-2.0.1-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:b7f2d075102dc8c794cbde1947378051c4e5180d52d276987b8d28a3bd58c17d"},
+    {file = "MarkupSafe-2.0.1-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e9936f0b261d4df76ad22f8fee3ae83b60d7c3e871292cd42f40b81b70afae85"},
+    {file = "MarkupSafe-2.0.1-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:2a7d351cbd8cfeb19ca00de495e224dea7e7d919659c2841bbb7f420ad03e2d6"},
+    {file = "MarkupSafe-2.0.1-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:60bf42e36abfaf9aff1f50f52644b336d4f0a3fd6d8a60ca0d054ac9f713a864"},
     {file = "MarkupSafe-2.0.1-cp37-cp37m-win32.whl", hash = "sha256:a30e67a65b53ea0a5e62fe23682cfe22712e01f453b95233b25502f7c61cb415"},
     {file = "MarkupSafe-2.0.1-cp37-cp37m-win_amd64.whl", hash = "sha256:611d1ad9a4288cf3e3c16014564df047fe08410e628f89805e475368bd304914"},
+    {file = "MarkupSafe-2.0.1-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:5bb28c636d87e840583ee3adeb78172efc47c8b26127267f54a9c0ec251d41a9"},
     {file = "MarkupSafe-2.0.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:be98f628055368795d818ebf93da628541e10b75b41c559fdf36d104c5787066"},
     {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux1_i686.whl", hash = "sha256:1d609f577dc6e1aa17d746f8bd3c31aa4d258f4070d61b2aa5c4166c1539de35"},
     {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:7d91275b0245b1da4d4cfa07e0faedd5b0812efc15b702576d103293e252af1b"},
     {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:01a9b8ea66f1658938f65b93a85ebe8bc016e6769611be228d797c9d998dd298"},
     {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:47ab1e7b91c098ab893b828deafa1203de86d0bc6ab587b160f78fe6c4011f75"},
     {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:97383d78eb34da7e1fa37dd273c20ad4320929af65d156e35a5e2d89566d9dfb"},
+    {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6fcf051089389abe060c9cd7caa212c707e58153afa2c649f00346ce6d260f1b"},
+    {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:5855f8438a7d1d458206a2466bf82b0f104a3724bf96a1c781ab731e4201731a"},
+    {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:3dd007d54ee88b46be476e293f48c85048603f5f516008bee124ddd891398ed6"},
     {file = "MarkupSafe-2.0.1-cp38-cp38-win32.whl", hash = "sha256:023cb26ec21ece8dc3907c0e8320058b2e0cb3c55cf9564da612bc325bed5e64"},
     {file = "MarkupSafe-2.0.1-cp38-cp38-win_amd64.whl", hash = "sha256:984d76483eb32f1bcb536dc27e4ad56bba4baa70be32fa87152832cdd9db0833"},
     {file = "MarkupSafe-2.0.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:2ef54abee730b502252bcdf31b10dacb0a416229b72c18b19e24a4509f273d26"},
@@ -1521,6 +1546,9 @@ markupsafe = [
     {file = "MarkupSafe-2.0.1-cp39-cp39-manylinux2010_i686.whl", hash = "sha256:4efca8f86c54b22348a5467704e3fec767b2db12fc39c6d963168ab1d3fc9135"},
     {file = "MarkupSafe-2.0.1-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:ab3ef638ace319fa26553db0624c4699e31a28bb2a835c5faca8f8acf6a5a902"},
     {file = "MarkupSafe-2.0.1-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:f8ba0e8349a38d3001fae7eadded3f6606f0da5d748ee53cc1dab1d6527b9509"},
+    {file = "MarkupSafe-2.0.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c47adbc92fc1bb2b3274c4b3a43ae0e4573d9fbff4f54cd484555edbf030baf1"},
+    {file = "MarkupSafe-2.0.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:37205cac2a79194e3750b0af2a5720d95f786a55ce7df90c3af697bfa100eaac"},
+    {file = "MarkupSafe-2.0.1-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:1f2ade76b9903f39aa442b4aadd2177decb66525062db244b35d71d0ee8599b6"},
     {file = "MarkupSafe-2.0.1-cp39-cp39-win32.whl", hash = "sha256:10f82115e21dc0dfec9ab5c0223652f7197feb168c940f3ef61563fc2d6beb74"},
     {file = "MarkupSafe-2.0.1-cp39-cp39-win_amd64.whl", hash = "sha256:693ce3f9e70a6cf7d2fb9e6c9d8b204b6b39897a2c4a1aa65728d5ac97dcc1d8"},
     {file = "MarkupSafe-2.0.1.tar.gz", hash = "sha256:594c67807fb16238b30c44bdf74f36c02cdf22d1c8cda91ef8a0ed8dabf5620a"},
@@ -1837,8 +1865,8 @@ urllib3 = [
     {file = "urllib3-1.26.6.tar.gz", hash = "sha256:f57b4c16c62fa2760b7e3d97c35b255512fb6b59a259730f36ba32ce9f8e342f"},
 ]
 uvicorn = [
-    {file = "uvicorn-0.14.0-py3-none-any.whl", hash = "sha256:2a76bb359171a504b3d1c853409af3adbfa5cef374a4a59e5881945a97a93eae"},
-    {file = "uvicorn-0.14.0.tar.gz", hash = "sha256:45ad7dfaaa7d55cab4cd1e85e03f27e9d60bc067ddc59db52a2b0aeca8870292"},
+    {file = "uvicorn-0.15.0-py3-none-any.whl", hash = "sha256:17f898c64c71a2640514d4089da2689e5db1ce5d4086c2d53699bf99513421c1"},
+    {file = "uvicorn-0.15.0.tar.gz", hash = "sha256:d9a3c0dd1ca86728d3e235182683b4cf94cd53a867c288eaeca80ee781b2caff"},
 ]
 uvloop = [
     {file = "uvloop-0.16.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:6224f1401025b748ffecb7a6e2652b17768f30b1a6a3f7b44660e5b5b690b12d"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -61,6 +61,19 @@ lazy-object-proxy = ">=1.4.0"
 wrapt = ">=1.11,<1.13"
 
 [[package]]
+name = "asyncpg"
+version = "0.24.0"
+description = "An asyncio PostgreSQL driver"
+category = "main"
+optional = false
+python-versions = ">=3.6.0"
+
+[package.extras]
+dev = ["Cython (>=0.29.24,<0.30.0)", "pytest (>=6.0)", "Sphinx (>=4.1.2,<4.2.0)", "sphinxcontrib-asyncio (>=0.3.0,<0.4.0)", "sphinx-rtd-theme (>=0.5.2,<0.6.0)", "pycodestyle (>=2.7.0,<2.8.0)", "flake8 (>=3.9.2,<3.10.0)", "uvloop (>=0.15.3)"]
+docs = ["Sphinx (>=4.1.2,<4.2.0)", "sphinxcontrib-asyncio (>=0.3.0,<0.4.0)", "sphinx-rtd-theme (>=0.5.2,<0.6.0)"]
+test = ["pycodestyle (>=2.7.0,<2.8.0)", "flake8 (>=3.9.2,<3.10.0)", "uvloop (>=0.15.3)"]
+
+[[package]]
 name = "atomicwrites"
 version = "1.4.0"
 description = "Atomic file writes."
@@ -957,7 +970,7 @@ python-versions = "*"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.9"
-content-hash = "b92cca87e7be78c70b1ba17cd485d5032afd961d915a1d72297ecfe401068830"
+content-hash = "99bd7496e8d17d3d5a91c00a88de759c020eb888b7079dadb55149f24895a54d"
 
 [metadata.files]
 alembic = [
@@ -995,6 +1008,21 @@ asgiref = [
 astroid = [
     {file = "astroid-2.6.6-py3-none-any.whl", hash = "sha256:ab7f36e8a78b8e54a62028ba6beef7561db4cdb6f2a5009ecc44a6f42b5697ef"},
     {file = "astroid-2.6.6.tar.gz", hash = "sha256:3975a0bd5373bdce166e60c851cfcbaf21ee96de80ec518c1f4cb3e94c3fb334"},
+]
+asyncpg = [
+    {file = "asyncpg-0.24.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:c4fc0205fe4ddd5aeb3dfdc0f7bafd43411181e1f5650189608e5971cceacff1"},
+    {file = "asyncpg-0.24.0-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:a7095890c96ba36f9f668eb552bb020dddb44f8e73e932f8573efc613ee83843"},
+    {file = "asyncpg-0.24.0-cp310-cp310-win_amd64.whl", hash = "sha256:8ff5073d4b654e34bd5eaadc01dc4d68b8a9609084d835acd364cd934190a08d"},
+    {file = "asyncpg-0.24.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:e36c6806883786b19551bb70a4882561f31135dc8105a59662e0376cf5b2cbc5"},
+    {file = "asyncpg-0.24.0-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:ddffcb85227bf39cd1bedd4603e0082b243cf3b14ced64dce506a15b05232b83"},
+    {file = "asyncpg-0.24.0-cp37-cp37m-win_amd64.whl", hash = "sha256:41704c561d354bef01353835a7846e5606faabbeb846214dfcf666cf53319f18"},
+    {file = "asyncpg-0.24.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:29ef6ae0a617fc13cc2ac5dc8e9b367bb83cba220614b437af9b67766f4b6b20"},
+    {file = "asyncpg-0.24.0-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:eed43abc6ccf1dc02e0d0efc06ce46a411362f3358847c6b0ec9a43426f91ece"},
+    {file = "asyncpg-0.24.0-cp38-cp38-win_amd64.whl", hash = "sha256:129d501f3d30616afd51eb8d3142ef51ba05374256bd5834cec3ef4956a9b317"},
+    {file = "asyncpg-0.24.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:a458fc69051fbb67d995fdda46d75a012b5d6200f91e17d23d4751482640ed4c"},
+    {file = "asyncpg-0.24.0-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:556b0e92e2b75dc028b3c4bc9bd5162ddf0053b856437cf1f04c97f9c6837d03"},
+    {file = "asyncpg-0.24.0-cp39-cp39-win_amd64.whl", hash = "sha256:a738f4807c853623d3f93f0fea11f61be6b0e5ca16ea8aeb42c2c7ee742aa853"},
+    {file = "asyncpg-0.24.0.tar.gz", hash = "sha256:dd2fa063c3344823487d9ddccb40802f02622ddf8bf8a6cc53885ee7a2c1c0c6"},
 ]
 atomicwrites = [
     {file = "atomicwrites-1.4.0-py2.py3-none-any.whl", hash = "sha256:6d1784dea7c0c8d4a5172b6c620f40b6e4cbfdf96d783691f2e1302a7b88e197"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -13,6 +13,23 @@ python-editor = ">=0.3"
 SQLAlchemy = ">=1.3.0"
 
 [[package]]
+name = "anyio"
+version = "3.3.0"
+description = "High level compatibility layer for multiple asynchronous event loop implementations"
+category = "dev"
+optional = false
+python-versions = ">=3.6.2"
+
+[package.dependencies]
+idna = ">=2.8"
+sniffio = ">=1.1"
+
+[package.extras]
+doc = ["sphinx-rtd-theme", "sphinx-autodoc-typehints (>=1.2.0)"]
+test = ["coverage[toml] (>=4.5)", "hypothesis (>=4.0)", "pytest (>=6.0)", "pytest-mock (>=3.6.1)", "trustme", "uvloop (<0.15)", "mock (>=4)", "uvloop (>=0.15)"]
+trio = ["trio (>=0.16)"]
+
+[[package]]
 name = "appdirs"
 version = "1.4.4"
 description = "A small Python module for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
@@ -353,6 +370,22 @@ optional = false
 python-versions = ">=3.6"
 
 [[package]]
+name = "httpcore"
+version = "0.13.6"
+description = "A minimal low-level HTTP client."
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+anyio = ">=3.0.0,<4.0.0"
+h11 = ">=0.11,<0.13"
+sniffio = ">=1.0.0,<2.0.0"
+
+[package.extras]
+http2 = ["h2 (>=3,<5)"]
+
+[[package]]
 name = "httptools"
 version = "0.2.0"
 description = "A collection of framework independent HTTP protocol utils."
@@ -362,6 +395,24 @@ python-versions = "*"
 
 [package.extras]
 test = ["Cython (==0.29.22)"]
+
+[[package]]
+name = "httpx"
+version = "0.18.2"
+description = "The next generation HTTP client."
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+certifi = "*"
+httpcore = ">=0.13.3,<0.14.0"
+rfc3986 = {version = ">=1.3,<2", extras = ["idna2008"]}
+sniffio = "*"
+
+[package.extras]
+brotli = ["brotlicffi (>=1.0.0,<2.0.0)"]
+http2 = ["h2 (>=3.0.0,<4.0.0)"]
 
 [[package]]
 name = "idna"
@@ -769,6 +820,20 @@ socks = ["PySocks (>=1.5.6,!=1.5.7)", "win-inet-pton"]
 use_chardet_on_py3 = ["chardet (>=3.0.2,<5)"]
 
 [[package]]
+name = "rfc3986"
+version = "1.5.0"
+description = "Validating URI References per RFC 3986"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+idna = {version = "*", optional = true, markers = "extra == \"idna2008\""}
+
+[package.extras]
+idna2008 = ["idna"]
+
+[[package]]
 name = "rsa"
 version = "4.7.2"
 description = "Pure-Python RSA implementation"
@@ -786,6 +851,14 @@ description = "Python 2 and 3 compatibility utilities"
 category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
+
+[[package]]
+name = "sniffio"
+version = "1.2.0"
+description = "Sniff out which async library your code is running under"
+category = "dev"
+optional = false
+python-versions = ">=3.5"
 
 [[package]]
 name = "sqlalchemy"
@@ -984,12 +1057,16 @@ python-versions = "*"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.9"
-content-hash = "cb3587a6569672347cec982cf1a320441073e045e187f3d9e7e7c5f7cfd44dd7"
+content-hash = "61e56445c163a206392c58cf9db70b41a73c8f43e1c9a399817adbb6acd9effa"
 
 [metadata.files]
 alembic = [
     {file = "alembic-1.6.5-py2.py3-none-any.whl", hash = "sha256:e78be5b919f5bb184e3e0e2dd1ca986f2362e29a2bc933c446fe89f39dbe4e9c"},
     {file = "alembic-1.6.5.tar.gz", hash = "sha256:a21fedebb3fb8f6bbbba51a11114f08c78709377051384c9c5ead5705ee93a51"},
+]
+anyio = [
+    {file = "anyio-3.3.0-py3-none-any.whl", hash = "sha256:929a6852074397afe1d989002aa96d457e3e1e5441357c60d03e7eea0e65e1b0"},
+    {file = "anyio-3.3.0.tar.gz", hash = "sha256:ae57a67583e5ff8b4af47666ff5651c3732d45fd26c929253748e796af860374"},
 ]
 appdirs = [
     {file = "appdirs-1.4.4-py2.py3-none-any.whl", hash = "sha256:a841dacd6b99318a741b166adb07e19ee71a274450e68237b4650ca1055ab128"},
@@ -1280,6 +1357,10 @@ h11 = [
     {file = "h11-0.12.0-py3-none-any.whl", hash = "sha256:36a3cb8c0a032f56e2da7084577878a035d3b61d104230d4bd49c0c6b555a9c6"},
     {file = "h11-0.12.0.tar.gz", hash = "sha256:47222cb6067e4a307d535814917cd98fd0a57b6788ce715755fa2b6c28b56042"},
 ]
+httpcore = [
+    {file = "httpcore-0.13.6-py3-none-any.whl", hash = "sha256:db4c0dcb8323494d01b8c6d812d80091a31e520033e7b0120883d6f52da649ff"},
+    {file = "httpcore-0.13.6.tar.gz", hash = "sha256:b0d16f0012ec88d8cc848f5a55f8a03158405f4bca02ee49bc4ca2c1fda49f3e"},
+]
 httptools = [
     {file = "httptools-0.2.0-cp35-cp35m-macosx_10_14_x86_64.whl", hash = "sha256:79dbc21f3612a78b28384e989b21872e2e3cf3968532601544696e4ed0007ce5"},
     {file = "httptools-0.2.0-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:78d03dd39b09c99ec917d50189e6743adbfd18c15d5944392d2eabda688bf149"},
@@ -1296,6 +1377,10 @@ httptools = [
     {file = "httptools-0.2.0-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:fd3b8905e21431ad306eeaf56644a68fdd621bf8f3097eff54d0f6bdf7262065"},
     {file = "httptools-0.2.0-cp39-cp39-win_amd64.whl", hash = "sha256:200fc1cdf733a9ff554c0bb97a4047785cfaad9875307d6087001db3eb2b417f"},
     {file = "httptools-0.2.0.tar.gz", hash = "sha256:94505026be56652d7a530ab03d89474dc6021019d6b8682281977163b3471ea0"},
+]
+httpx = [
+    {file = "httpx-0.18.2-py3-none-any.whl", hash = "sha256:979afafecb7d22a1d10340bafb403cf2cb75aff214426ff206521fc79d26408c"},
+    {file = "httpx-0.18.2.tar.gz", hash = "sha256:9f99c15d33642d38bce8405df088c1c4cfd940284b4290cacbfb02e64f4877c6"},
 ]
 idna = [
     {file = "idna-3.2-py3-none-any.whl", hash = "sha256:14475042e284991034cb48e06f6851428fb14c4dc953acd9be9a5e95c7b6dd7a"},
@@ -1648,6 +1733,10 @@ requests = [
     {file = "requests-2.26.0-py2.py3-none-any.whl", hash = "sha256:6c1246513ecd5ecd4528a0906f910e8f0f9c6b8ec72030dc9fd154dc1a6efd24"},
     {file = "requests-2.26.0.tar.gz", hash = "sha256:b8aa58f8cf793ffd8782d3d8cb19e66ef36f7aba4353eec859e74678b01b07a7"},
 ]
+rfc3986 = [
+    {file = "rfc3986-1.5.0-py2.py3-none-any.whl", hash = "sha256:a86d6e1f5b1dc238b218b012df0aa79409667bb209e58da56d0b94704e712a97"},
+    {file = "rfc3986-1.5.0.tar.gz", hash = "sha256:270aaf10d87d0d4e095063c65bf3ddbc6ee3d0b226328ce21e036f946e421835"},
+]
 rsa = [
     {file = "rsa-4.7.2-py3-none-any.whl", hash = "sha256:78f9a9bf4e7be0c5ded4583326e7461e3a3c5aae24073648b4bdfa797d78c9d2"},
     {file = "rsa-4.7.2.tar.gz", hash = "sha256:9d689e6ca1b3038bc82bf8d23e944b6b6037bc02301a574935b2dd946e0353b9"},
@@ -1655,6 +1744,10 @@ rsa = [
 six = [
     {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},
     {file = "six-1.16.0.tar.gz", hash = "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"},
+]
+sniffio = [
+    {file = "sniffio-1.2.0-py3-none-any.whl", hash = "sha256:471b71698eac1c2112a40ce2752bb2f4a4814c22a54a3eed3676bc0f5ca9f663"},
+    {file = "sniffio-1.2.0.tar.gz", hash = "sha256:c4666eecec1d3f50960c6bdf61ab7bc350648da6c126e3cf6898d8cd4ddcd3de"},
 ]
 sqlalchemy = [
     {file = "SQLAlchemy-1.4.22-cp27-cp27m-macosx_10_14_x86_64.whl", hash = "sha256:488608953385d6c127d2dcbc4b11f8d7f2f30b89f6bd27c01b042253d985cc2f"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -55,6 +55,17 @@ docs = ["sphinx"]
 tests = ["coverage[toml] (>=5.0.2)", "hypothesis", "pytest"]
 
 [[package]]
+name = "asgi-lifespan"
+version = "1.0.1"
+description = "Programmatic startup/shutdown of ASGI apps."
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+sniffio = "*"
+
+[[package]]
 name = "asgiref"
 version = "3.4.1"
 description = "ASGI specs, helper code, and adapters"
@@ -1019,16 +1030,16 @@ standard = ["websockets (>=9.1)", "httptools (>=0.2.0,<0.3.0)", "watchgod (>=0.6
 
 [[package]]
 name = "uvloop"
-version = "0.15.3"
+version = "0.16.0"
 description = "Fast implementation of asyncio event loop on top of libuv"
 category = "main"
 optional = false
 python-versions = ">=3.7"
 
 [package.extras]
-dev = ["Cython (>=0.29.20,<0.30.0)", "pytest (>=3.6.0)", "Sphinx (>=1.7.3,<1.8.0)", "sphinxcontrib-asyncio (>=0.2.0,<0.3.0)", "sphinx-rtd-theme (>=0.2.4,<0.3.0)", "aiohttp", "flake8 (>=3.8.4,<3.9.0)", "psutil", "pycodestyle (>=2.6.0,<2.7.0)", "pyOpenSSL (>=19.0.0,<19.1.0)", "mypy (>=0.800)"]
-docs = ["Sphinx (>=1.7.3,<1.8.0)", "sphinxcontrib-asyncio (>=0.2.0,<0.3.0)", "sphinx-rtd-theme (>=0.2.4,<0.3.0)"]
-test = ["aiohttp", "flake8 (>=3.8.4,<3.9.0)", "psutil", "pycodestyle (>=2.6.0,<2.7.0)", "pyOpenSSL (>=19.0.0,<19.1.0)", "mypy (>=0.800)"]
+dev = ["Cython (>=0.29.24,<0.30.0)", "pytest (>=3.6.0)", "Sphinx (>=4.1.2,<4.2.0)", "sphinxcontrib-asyncio (>=0.3.0,<0.4.0)", "sphinx-rtd-theme (>=0.5.2,<0.6.0)", "aiohttp", "flake8 (>=3.9.2,<3.10.0)", "psutil", "pycodestyle (>=2.7.0,<2.8.0)", "pyOpenSSL (>=19.0.0,<19.1.0)", "mypy (>=0.800)"]
+docs = ["Sphinx (>=4.1.2,<4.2.0)", "sphinxcontrib-asyncio (>=0.3.0,<0.4.0)", "sphinx-rtd-theme (>=0.5.2,<0.6.0)"]
+test = ["aiohttp", "flake8 (>=3.9.2,<3.10.0)", "psutil", "pycodestyle (>=2.7.0,<2.8.0)", "pyOpenSSL (>=19.0.0,<19.1.0)", "mypy (>=0.800)"]
 
 [[package]]
 name = "watchgod"
@@ -1057,7 +1068,7 @@ python-versions = "*"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.9"
-content-hash = "61e56445c163a206392c58cf9db70b41a73c8f43e1c9a399817adbb6acd9effa"
+content-hash = "e72fbf1742693edff7098b1bad34f59de1ffcce026c1d20bf9af5633ebf84005"
 
 [metadata.files]
 alembic = [
@@ -1091,6 +1102,10 @@ argon2-cffi = [
     {file = "argon2_cffi-20.1.0-cp38-cp38-win_amd64.whl", hash = "sha256:9dfd5197852530294ecb5795c97a823839258dfd5eb9420233c7cfedec2058f2"},
     {file = "argon2_cffi-20.1.0-cp39-cp39-win32.whl", hash = "sha256:e2db6e85c057c16d0bd3b4d2b04f270a7467c147381e8fd73cbbe5bc719832be"},
     {file = "argon2_cffi-20.1.0-cp39-cp39-win_amd64.whl", hash = "sha256:8a84934bd818e14a17943de8099d41160da4a336bcc699bb4c394bbb9b94bd32"},
+]
+asgi-lifespan = [
+    {file = "asgi-lifespan-1.0.1.tar.gz", hash = "sha256:9a33e7da2073c4764bc79bd6136501d6c42f60e3d2168ba71235e84122eadb7f"},
+    {file = "asgi_lifespan-1.0.1-py3-none-any.whl", hash = "sha256:9ea969dc5eb5cf08e52c08dce6f61afcadd28112e72d81c972b1d8eb8691ab53"},
 ]
 asgiref = [
     {file = "asgiref-3.4.1-py3-none-any.whl", hash = "sha256:ffc141aa908e6f175673e7b1b3b7af4fdb0ecb738fc5c8b88f69f055c2415214"},
@@ -1826,16 +1841,22 @@ uvicorn = [
     {file = "uvicorn-0.14.0.tar.gz", hash = "sha256:45ad7dfaaa7d55cab4cd1e85e03f27e9d60bc067ddc59db52a2b0aeca8870292"},
 ]
 uvloop = [
-    {file = "uvloop-0.15.3-cp37-cp37m-macosx_10_14_x86_64.whl", hash = "sha256:e71fb9038bfcd7646ca126c5ef19b17e48d4af9e838b2bcfda7a9f55a6552a32"},
-    {file = "uvloop-0.15.3-cp37-cp37m-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:7522df4e45e4f25b50adbbbeb5bb9847495c438a628177099d2721f2751ff825"},
-    {file = "uvloop-0.15.3-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ae2b325c0f6d748027f7463077e457006b4fdb35a8788f01754aadba825285ee"},
-    {file = "uvloop-0.15.3-cp38-cp38-macosx_10_14_x86_64.whl", hash = "sha256:0de811931e90ae2da9e19ce70ffad73047ab0c1dba7c6e74f9ae1a3aabeb89bd"},
-    {file = "uvloop-0.15.3-cp38-cp38-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:7f4b8a905df909a407c5791fb582f6c03b0d3b491ecdc1cdceaefbc9bf9e08f6"},
-    {file = "uvloop-0.15.3-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2d8ffe44ae709f839c54bacf14ed283f41bee90430c3b398e521e10f8d117b3a"},
-    {file = "uvloop-0.15.3-cp39-cp39-macosx_10_14_x86_64.whl", hash = "sha256:63a3288abbc9c8ee979d7e34c34e780b2fbab3e7e53d00b6c80271119f277399"},
-    {file = "uvloop-0.15.3-cp39-cp39-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:5cda65fc60a645470b8525ce014516b120b7057b576fa876cdfdd5e60ab1efbb"},
-    {file = "uvloop-0.15.3-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1ff05116ede1ebdd81802df339e5b1d4cab1dfbd99295bf27e90b4cec64d70e9"},
-    {file = "uvloop-0.15.3.tar.gz", hash = "sha256:905f0adb0c09c9f44222ee02f6b96fd88b493478fffb7a345287f9444e926030"},
+    {file = "uvloop-0.16.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:6224f1401025b748ffecb7a6e2652b17768f30b1a6a3f7b44660e5b5b690b12d"},
+    {file = "uvloop-0.16.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:30ba9dcbd0965f5c812b7c2112a1ddf60cf904c1c160f398e7eed3a6b82dcd9c"},
+    {file = "uvloop-0.16.0-cp310-cp310-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:bd53f7f5db562f37cd64a3af5012df8cac2c464c97e732ed556800129505bd64"},
+    {file = "uvloop-0.16.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:772206116b9b57cd625c8a88f2413df2fcfd0b496eb188b82a43bed7af2c2ec9"},
+    {file = "uvloop-0.16.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:b572256409f194521a9895aef274cea88731d14732343da3ecdb175228881638"},
+    {file = "uvloop-0.16.0-cp37-cp37m-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:04ff57aa137230d8cc968f03481176041ae789308b4d5079118331ab01112450"},
+    {file = "uvloop-0.16.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3a19828c4f15687675ea912cc28bbcb48e9bb907c801873bd1519b96b04fb805"},
+    {file = "uvloop-0.16.0-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:e814ac2c6f9daf4c36eb8e85266859f42174a4ff0d71b99405ed559257750382"},
+    {file = "uvloop-0.16.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:bd8f42ea1ea8f4e84d265769089964ddda95eb2bb38b5cbe26712b0616c3edee"},
+    {file = "uvloop-0.16.0-cp38-cp38-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:647e481940379eebd314c00440314c81ea547aa636056f554d491e40503c8464"},
+    {file = "uvloop-0.16.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8e0d26fa5875d43ddbb0d9d79a447d2ace4180d9e3239788208527c4784f7cab"},
+    {file = "uvloop-0.16.0-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:6ccd57ae8db17d677e9e06192e9c9ec4bd2066b77790f9aa7dede2cc4008ee8f"},
+    {file = "uvloop-0.16.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:089b4834fd299d82d83a25e3335372f12117a7d38525217c2258e9b9f4578897"},
+    {file = "uvloop-0.16.0-cp39-cp39-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:98d117332cc9e5ea8dfdc2b28b0a23f60370d02e1395f88f40d1effd2cb86c4f"},
+    {file = "uvloop-0.16.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1e5f2e2ff51aefe6c19ee98af12b4ae61f5be456cd24396953244a30880ad861"},
+    {file = "uvloop-0.16.0.tar.gz", hash = "sha256:f74bc20c7b67d1c27c72601c78cf95be99d5c2cdd4514502b4f3eb0933ff1228"},
 ]
 watchgod = [
     {file = "watchgod-0.7-py3-none-any.whl", hash = "sha256:d6c1ea21df37847ac0537ca0d6c2f4cdf513562e95f77bb93abbcf05573407b7"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -262,6 +262,14 @@ docs = ["sphinx", "jaraco.packaging (>=8.2)", "rst.linker (>=1.9)"]
 testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "mock", "lxml", "cssselect", "pytest-black (>=0.3.7)", "pytest-mypy", "importlib-resources"]
 
 [[package]]
+name = "cython"
+version = "0.29.24"
+description = "The Cython compiler for writing C extensions for the Python language."
+category = "main"
+optional = false
+python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
+
+[[package]]
 name = "dnspython"
 version = "2.1.0"
 description = "DNS toolkit"
@@ -669,6 +677,7 @@ description = "Data validation and settings management using python 3.6 type hin
 category = "main"
 optional = false
 python-versions = ">=3.6.1"
+develop = false
 
 [package.dependencies]
 email-validator = {version = ">=1.0.3", optional = true, markers = "extra == \"email\""}
@@ -678,6 +687,12 @@ typing-extensions = ">=3.7.4.3"
 [package.extras]
 dotenv = ["python-dotenv (>=0.10.4)"]
 email = ["email-validator (>=1.0.3)"]
+
+[package.source]
+type = "git"
+url = "https://github.com/samuelcolvin/pydantic.git"
+reference = "cc1cb4826c74ac5b651ef2d80c3478428a9950ca"
+resolved_reference = "cc1cb4826c74ac5b651ef2d80c3478428a9950ca"
 
 [[package]]
 name = "pylint"
@@ -1084,7 +1099,7 @@ python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.9"
-content-hash = "f12bdc71184a958679702a13a4dcca613485c4d3bfd335f00a01d6e05c5f902f"
+content-hash = "38014b18174f014a579707bc761985865ba90be224dc3a1326b3d159e817bf78"
 
 [metadata.files]
 alembic = [
@@ -1302,6 +1317,47 @@ cssselect = [
 cssutils = [
     {file = "cssutils-2.3.0-py3-none-any.whl", hash = "sha256:0cf1f6086b020dee18048ff3999339499f725934017ef9ae2cd5bb77f9ab5f46"},
     {file = "cssutils-2.3.0.tar.gz", hash = "sha256:b2d3b16047caae82e5c590036935bafa1b621cf45c2f38885af4be4838f0fd00"},
+]
+cython = [
+    {file = "Cython-0.29.24-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:6a2cf2ccccc25413864928dfd730c29db6f63eaf98206c1e600003a445ca7f58"},
+    {file = "Cython-0.29.24-cp27-cp27m-manylinux1_i686.whl", hash = "sha256:b28f92e617f540d3f21f8fd479a9c6491be920ffff672a4c61b7fc4d7f749f39"},
+    {file = "Cython-0.29.24-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:37bcfa5df2a3009f49624695d917c3804fccbdfcdc5eda6378754a879711a4d5"},
+    {file = "Cython-0.29.24-cp27-cp27m-win32.whl", hash = "sha256:9164aeef1af6f837e4fc20402a31d256188ba4d535e262c6cb78caf57ad744f8"},
+    {file = "Cython-0.29.24-cp27-cp27m-win_amd64.whl", hash = "sha256:73ac33a4379056a02031baa4def255717fadb9181b5ac2b244792d53eae1c925"},
+    {file = "Cython-0.29.24-cp27-cp27mu-manylinux1_i686.whl", hash = "sha256:09ac3087ac7a3d489ebcb3fb8402e00c13d1a3a1c6bc73fd3b0d756a3e341e79"},
+    {file = "Cython-0.29.24-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:774cb8fd931ee1ba52c472bc1c19077cd6895c1b24014ae07bb27df59aed5ebe"},
+    {file = "Cython-0.29.24-cp34-cp34m-win32.whl", hash = "sha256:5dd56d0be50073f0e54825a8bc3393852de0eed126339ecbca0ae149dba55cfc"},
+    {file = "Cython-0.29.24-cp34-cp34m-win_amd64.whl", hash = "sha256:88dc3c250dec280b0489a83950b15809762e27232f4799b1b8d0bad503f5ab84"},
+    {file = "Cython-0.29.24-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:5fa12ebafc2f688ea6d26ab6d1d2e634a9872509ba7135b902bb0d8b368fb04b"},
+    {file = "Cython-0.29.24-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:60c958bcab0ff315b4036a949bed1c65334e1f6a69e17e9966d742febb59043a"},
+    {file = "Cython-0.29.24-cp35-cp35m-win32.whl", hash = "sha256:166f9f29cd0058ce1a14a7b3a2458b849ed34b1ec5fd4108af3fdd2c24afcbb0"},
+    {file = "Cython-0.29.24-cp35-cp35m-win_amd64.whl", hash = "sha256:76cbca0188d278e93d12ebdaf5990678e6e436485fdfad49dbe9b07717d41a3c"},
+    {file = "Cython-0.29.24-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:f2e9381497b12e8f622af620bde0d1d094035d79b899abb2ddd3a7891f535083"},
+    {file = "Cython-0.29.24-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:d8d1a087f35e39384303f5e6b75d465d6f29d746d7138eae9d3b6e8e6f769eae"},
+    {file = "Cython-0.29.24-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:112efa54a58293a4fb0acf0dd8e5b3736e95b595eee24dd88615648e445abe41"},
+    {file = "Cython-0.29.24-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4cf4452f0e4d50e11701bca38f3857fe6fa16593e7fd6a4d5f7be66f611b7da2"},
+    {file = "Cython-0.29.24-cp36-cp36m-win32.whl", hash = "sha256:854fe2193d3ad4c8b61932ff54d6dbe10c5fa8749eb8958d72cc0ab28243f833"},
+    {file = "Cython-0.29.24-cp36-cp36m-win_amd64.whl", hash = "sha256:84826ec1c11cda56261a252ddecac0c7d6b02e47e81b94f40b27b4c23c29c17c"},
+    {file = "Cython-0.29.24-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:6ade74eece909fd3a437d9a5084829180751d7ade118e281e9824dd75eafaff2"},
+    {file = "Cython-0.29.24-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:0a142c6b862e6ed6b02209d543062c038c110585b5e32d1ad7c9717af4f07e41"},
+    {file = "Cython-0.29.24-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:10cb3def9774fa99e4583617a5616874aed3255dc241fd1f4a3c2978c78e1c53"},
+    {file = "Cython-0.29.24-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2f41ef7edd76dd23315925e003f0c58c8585f3ab24be6885c4b3f60e77c82746"},
+    {file = "Cython-0.29.24-cp37-cp37m-win32.whl", hash = "sha256:821c2d416ad7d006b069657ee1034c0e0cb45bdbe9ab6ab631e8c495dfcfa4ac"},
+    {file = "Cython-0.29.24-cp37-cp37m-win_amd64.whl", hash = "sha256:2d9e61ed1056a3b6a4b9156b62297ad18b357a7948e57a2f49b061217696567e"},
+    {file = "Cython-0.29.24-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:55b0ee28c2c8118bfb3ad9b25cf7a6cbd724e442ea96956e32ccd908d5e3e043"},
+    {file = "Cython-0.29.24-cp38-cp38-manylinux1_i686.whl", hash = "sha256:eb2843f8cc01c645725e6fc690a84e99cdb266ce8ebe427cf3a680ff09f876aa"},
+    {file = "Cython-0.29.24-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:661dbdea519d9cfb288867252b75fef73ffa8e8bb674cec27acf70646afb369b"},
+    {file = "Cython-0.29.24-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bc05de569f811be1fcfde6756c9048ae518f0c4b6d9f8f024752c5365d934cac"},
+    {file = "Cython-0.29.24-cp38-cp38-win32.whl", hash = "sha256:a102cfa795c6b3b81a29bdb9dbec545367cd7f353c03e6f30a056fdfefd92854"},
+    {file = "Cython-0.29.24-cp38-cp38-win_amd64.whl", hash = "sha256:416046a98255eff97ec02077d20ebeaae52682dfca1c35aadf31260442b92514"},
+    {file = "Cython-0.29.24-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:ad43e684ade673565f6f9d6638015112f6c7f11aa2a632167b79014f613f0f5f"},
+    {file = "Cython-0.29.24-cp39-cp39-manylinux1_i686.whl", hash = "sha256:afb521523cb46ddaa8d269b421f88ea2731fee05e65b952b96d4db760f5a2a1c"},
+    {file = "Cython-0.29.24-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:0d414458cb22f8a90d64260da6dace5d5fcebde43f31be52ca51f818c46db8cb"},
+    {file = "Cython-0.29.24-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8cb87777e82d1996aef6c146560a19270684271c9c669ba62ac6803b3cd2ff82"},
+    {file = "Cython-0.29.24-cp39-cp39-win32.whl", hash = "sha256:91339ee4b465924a3ea4b2a9cec7f7227bc4cadf673ce859d24c2b9ef60b1214"},
+    {file = "Cython-0.29.24-cp39-cp39-win_amd64.whl", hash = "sha256:5fb977945a2111f6b64501fdf7ed0ec162cc502b84457fd648d6a558ea8de0d6"},
+    {file = "Cython-0.29.24-py2.py3-none-any.whl", hash = "sha256:f96411f0120b5cae483923aaacd2872af8709be4b46522daedc32f051d778385"},
+    {file = "Cython-0.29.24.tar.gz", hash = "sha256:cdf04d07c3600860e8c2ebaad4e8f52ac3feb212453c1764a49ac08c827e8443"},
 ]
 dnspython = [
     {file = "dnspython-2.1.0-py3-none-any.whl", hash = "sha256:95d12f6ef0317118d2a1a6fc49aac65ffec7eb8087474158f42f26a639135216"},
@@ -1681,30 +1737,7 @@ pycparser = [
     {file = "pycparser-2.21-py2.py3-none-any.whl", hash = "sha256:8ee45429555515e1f6b185e78100aea234072576aa43ab53aefcae078162fca9"},
     {file = "pycparser-2.21.tar.gz", hash = "sha256:e644fdec12f7872f86c58ff790da456218b10f863970249516d60a5eaca77206"},
 ]
-pydantic = [
-    {file = "pydantic-1.8.2-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:05ddfd37c1720c392f4e0d43c484217b7521558302e7069ce8d318438d297739"},
-    {file = "pydantic-1.8.2-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:a7c6002203fe2c5a1b5cbb141bb85060cbff88c2d78eccbc72d97eb7022c43e4"},
-    {file = "pydantic-1.8.2-cp36-cp36m-manylinux2014_i686.whl", hash = "sha256:589eb6cd6361e8ac341db97602eb7f354551482368a37f4fd086c0733548308e"},
-    {file = "pydantic-1.8.2-cp36-cp36m-manylinux2014_x86_64.whl", hash = "sha256:10e5622224245941efc193ad1d159887872776df7a8fd592ed746aa25d071840"},
-    {file = "pydantic-1.8.2-cp36-cp36m-win_amd64.whl", hash = "sha256:99a9fc39470010c45c161a1dc584997f1feb13f689ecf645f59bb4ba623e586b"},
-    {file = "pydantic-1.8.2-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:a83db7205f60c6a86f2c44a61791d993dff4b73135df1973ecd9eed5ea0bda20"},
-    {file = "pydantic-1.8.2-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:41b542c0b3c42dc17da70554bc6f38cbc30d7066d2c2815a94499b5684582ecb"},
-    {file = "pydantic-1.8.2-cp37-cp37m-manylinux2014_i686.whl", hash = "sha256:ea5cb40a3b23b3265f6325727ddfc45141b08ed665458be8c6285e7b85bd73a1"},
-    {file = "pydantic-1.8.2-cp37-cp37m-manylinux2014_x86_64.whl", hash = "sha256:18b5ea242dd3e62dbf89b2b0ec9ba6c7b5abaf6af85b95a97b00279f65845a23"},
-    {file = "pydantic-1.8.2-cp37-cp37m-win_amd64.whl", hash = "sha256:234a6c19f1c14e25e362cb05c68afb7f183eb931dd3cd4605eafff055ebbf287"},
-    {file = "pydantic-1.8.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:021ea0e4133e8c824775a0cfe098677acf6fa5a3cbf9206a376eed3fc09302cd"},
-    {file = "pydantic-1.8.2-cp38-cp38-manylinux1_i686.whl", hash = "sha256:e710876437bc07bd414ff453ac8ec63d219e7690128d925c6e82889d674bb505"},
-    {file = "pydantic-1.8.2-cp38-cp38-manylinux2014_i686.whl", hash = "sha256:ac8eed4ca3bd3aadc58a13c2aa93cd8a884bcf21cb019f8cfecaae3b6ce3746e"},
-    {file = "pydantic-1.8.2-cp38-cp38-manylinux2014_x86_64.whl", hash = "sha256:4a03cbbe743e9c7247ceae6f0d8898f7a64bb65800a45cbdc52d65e370570820"},
-    {file = "pydantic-1.8.2-cp38-cp38-win_amd64.whl", hash = "sha256:8621559dcf5afacf0069ed194278f35c255dc1a1385c28b32dd6c110fd6531b3"},
-    {file = "pydantic-1.8.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:8b223557f9510cf0bfd8b01316bf6dd281cf41826607eada99662f5e4963f316"},
-    {file = "pydantic-1.8.2-cp39-cp39-manylinux1_i686.whl", hash = "sha256:244ad78eeb388a43b0c927e74d3af78008e944074b7d0f4f696ddd5b2af43c62"},
-    {file = "pydantic-1.8.2-cp39-cp39-manylinux2014_i686.whl", hash = "sha256:05ef5246a7ffd2ce12a619cbb29f3307b7c4509307b1b49f456657b43529dc6f"},
-    {file = "pydantic-1.8.2-cp39-cp39-manylinux2014_x86_64.whl", hash = "sha256:54cd5121383f4a461ff7644c7ca20c0419d58052db70d8791eacbbe31528916b"},
-    {file = "pydantic-1.8.2-cp39-cp39-win_amd64.whl", hash = "sha256:4be75bebf676a5f0f87937c6ddb061fa39cbea067240d98e298508c1bda6f3f3"},
-    {file = "pydantic-1.8.2-py3-none-any.whl", hash = "sha256:fec866a0b59f372b7e776f2d7308511784dace622e0992a0b59ea3ccee0ae833"},
-    {file = "pydantic-1.8.2.tar.gz", hash = "sha256:26464e57ccaafe72b7ad156fdaa4e9b9ef051f69e175dbbb463283000c05ab7b"},
-]
+pydantic = []
 pylint = [
     {file = "pylint-2.12.1-py3-none-any.whl", hash = "sha256:b4b5a7b6d04e914a11c198c816042af1fb2d3cda29bb0c98a9c637010da2a5c5"},
     {file = "pylint-2.12.1.tar.gz", hash = "sha256:4f4a52b132c05b49094b28e109febcec6bfb7bc6961c7485a5ad0a0f961df289"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ SQLAlchemy        = { extras = [ "asyncio" ], version = "^1.4.22" }
 starlette-context = "^0.3.3"
 structlog         = "^21.1.0"
 tenacity          = "^8.0.1"
-uvicorn           = { extras = [ "standard" ], version = "^0.14.0" }
+uvicorn           = { extras = [ "standard" ], version = "^0.15.0" }
 
 [tool.poetry.dev-dependencies]
 asgi-lifespan     = { version = "^1.0.1", allow-prereleases = true }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ uvicorn           = { extras = [ "standard" ], version = "^0.14.0" }
 [tool.poetry.dev-dependencies]
 black             = { version = "^21.6b0", allow-prereleases = true }
 docformatter      = { version = "^1.4", allow-prereleases = true }
+httpx             = { version = "^0.18.2", allow-prereleases = true }
 isort             = { version = "^5.9.2", allow-prereleases = true }
 mypy              = { version = "^0.910", allow-prereleases = true }
 pylint            = { version = "^2.9.3", allow-prereleases = true }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ tenacity          = "^8.0.1"
 uvicorn           = { extras = [ "standard" ], version = "^0.14.0" }
 
 [tool.poetry.dev-dependencies]
+asgi-lifespan     = { version = "^1.0.1", allow-prereleases = true }
 black             = { version = "^21.6b0", allow-prereleases = true }
 docformatter      = { version = "^1.4", allow-prereleases = true }
 httpx             = { version = "^0.18.2", allow-prereleases = true }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ isort             = { version = "^5.9.2", allow-prereleases = true }
 mypy              = { version = "^0.910", allow-prereleases = true }
 pylint            = { version = "^2.9.3", allow-prereleases = true }
 pytest            = { version = "^6.2.4", allow-prereleases = true }
+pytest-asyncio    = { version = "^0.15.1", allow-prereleases = true }
 pytest-cov        = { version = "^2.12.1", allow-prereleases = true }
 sqlalchemy2-stubs = { version = "^0.0.2a5", allow-prereleases = true }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ authors     = [ "Your Name <you@example.com>" ]
 [tool.poetry.dependencies]
 python            = "^3.9"
 alembic           = "^1.6.5"
+asyncpg           = "^0.24.0"
 colorama          = "^0.4.4"
 emails            = "^0.6"
 fastapi           = "^0.68.0"
@@ -17,7 +18,7 @@ psycopg2          = "^2.9.1"
 pydantic          = { extras = [ "dotenv", "email" ], version = "^1.8.2" }
 python-jose       = { extras = [ "cryptography" ], version = "^3.3.0" }
 python-multipart  = "^0.0.5"
-SQLAlchemy        = "^1.4.22"
+SQLAlchemy        = { extras = [ "asyncio" ], version = "^1.4.22" }
 starlette-context = "^0.3.3"
 structlog         = "^21.1.0"
 tenacity          = "^8.0.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,24 +5,28 @@ description = "Decrypto API"
 authors     = [ "Your Name <you@example.com>" ]
 
 [tool.poetry.dependencies]
-python            = "^3.9"
-alembic           = "^1.7.5"
-asyncpg           = "^0.24.0"
-colorama          = "^0.4.4"
-emails            = "^0.6"
-fastapi           = "^0.70.0"
-gunicorn          = "^20.1.0"
-Jinja2            = "^3.0.3"
-passlib           = { extras = [ "argon2" ], version = "^1.7.4" }
-psycopg2          = "^2.9.2"
-pydantic          = { extras = [ "dotenv", "email" ], version = "^1.8.2" }
-python-jose       = { extras = [ "cryptography" ], version = "^3.3.0" }
-python-multipart  = "^0.0.5"
-SQLAlchemy        = { extras = [ "asyncio" ], version = "^1.4.27" }
+python = "^3.9"
+alembic = "^1.7.5"
+asyncpg = "^0.24.0"
+colorama = "^0.4.4"
+Cython = "^0.29.24"
+emails = "^0.6"
+fastapi = "^0.70.0"
+gunicorn = "^20.1.0"
+Jinja2 = "^3.0.3"
+passlib = { extras = [ "argon2" ], version = "^1.7.4" }
+psycopg2 = "^2.9.2"
+python-jose = { extras = [ "cryptography" ], version = "^3.3.0" }
+python-multipart = "^0.0.5"
+SQLAlchemy = { extras = [ "asyncio" ], version = "^1.4.27" }
 starlette-context = "^0.3.3"
-structlog         = "^21.3.0"
-tenacity          = "^8.0.1"
-uvicorn           = { extras = [ "standard" ], version = "^0.15.0" }
+structlog = "^21.3.0"
+tenacity = "^8.0.1"
+uvicorn = { extras = [ "standard" ], version = "^0.15.0" }
+pydantic = { git = "https://github.com/samuelcolvin/pydantic.git", rev = "cc1cb4826c74ac5b651ef2d80c3478428a9950ca", extras = [
+    "dotenv",
+    "email",
+] }
 
 [tool.poetry.dev-dependencies]
 asgi-lifespan     = { version = "^1.0.1", allow-prereleases = true }


### PR DESCRIPTION
Closes #6.

# Checklist:

- [x] Revert to `PostgresDsn` for `SQLALCHEMY_DATABASE_URI` and `SQLALCHEMY_TEST_DATABASE_URI` after https://github.com/samuelcolvin/pydantic/pull/2567 is merged.
  Dropping e14f21fa760ae88fd312577f229c32f4188ba3de and e2df4df21e987df7ec5f68f8a00d8cc6a340c2bd, and changing the scheme to `postgresql+asyncpg` in the validators should suffice.
